### PR TITLE
Fix #349: Added VM Retry Counter & the functionalities to set it to default

### DIFF
--- a/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBroker.java
+++ b/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBroker.java
@@ -57,8 +57,6 @@ public interface DatacenterBroker extends SimEntity {
      */
     double DEF_VM_DESTRUCTION_DELAY = -1.0;
 
-    int DEF_CURRENT_VM_CREATION_RETRIES = 1;
-
     /**
      * Specifies that an already submitted cloudlet, which is in the
      * {@link #getCloudletWaitingList() waiting list}, must run in a specific virtual machine.
@@ -451,56 +449,9 @@ public interface DatacenterBroker extends SimEntity {
      *
      * @param <T> the class of VMs inside the list
      * @return the list of failed VMs
-     * @see #setFailedVmsRetryDelay(double)
+     * @see VmCreationRetry#setFailedVmsRetryDelay(double)
      */
     <T extends Vm> List<T> getVmFailedList();
-
-    /**
-     * Checks if the broker has to retry allocating VMs
-     * that couldn't be placed due to lack of suitable Hosts.
-     * @return
-     */
-    boolean isRetryFailedVms();
-
-    /**
-     * Gets a delay (in seconds) for the broker to retry allocating VMs
-     * that couldn't be placed due to lack of suitable active Hosts.
-     *
-     * @return
-     * <ul>
-     *  <li>a value larger than zero to indicate the broker will retry
-     *  to place failed VM as soon as new VMs or Cloudlets
-     *  are submitted or after the given delay.</li>
-     *  <li>otherwise, to indicate failed VMs will be just added to the
-     *  {@link #getVmFailedList()} and the user simulation have to deal with it.
-     *  If the VM has an {@link Vm#addOnCreationFailureListener(EventListener) OnCreationFailureListener},
-     *  it will be notified about the failure.</li>
-     * </ul>
-     */
-    double getFailedVmsRetryDelay();
-
-    /**
-     * Sets a delay (in seconds) for the broker to retry allocating VMs
-     * that couldn't be placed due to lack of suitable active Hosts.
-     *
-     * Setting the attribute as:
-     * <ul>
-     *  <li>larger than zero, the broker will retry to place failed VM as soon as new VMs or Cloudlets
-     *  are submitted or after the given delay.</li>
-     *  <li>otherwise, failed VMs will be just added to the {@link #getVmFailedList()}
-     *  and the user simulation have to deal with it.
-     *  If the VM has an {@link Vm#addOnCreationFailureListener(EventListener) OnCreationFailureListener},
-     *  it will be notified about the failure.</li>
-     * </ul>
-     * @param failedVmsRetryDelay
-     */
-    void setFailedVmsRetryDelay(double failedVmsRetryDelay);
-
-    void incrementCurrentVmCreationRetries();
-
-    void setCurrentVmCreationRetries(int currentVmCreationRetries);
-
-    int getCurrentVmCreationRetries();
 
     /**
      * Checks if the broker must be shut down after becoming idle.
@@ -513,4 +464,8 @@ public interface DatacenterBroker extends SimEntity {
      * @return
      */
     DatacenterBroker setShutdownWhenIdle(boolean shutdownWhenIdle);
+
+    VmCreationRetry getVmCreationRetry();
+
+    void setVmCreationRetry(VmCreationRetry vmCreationRetry);
 }

--- a/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBroker.java
+++ b/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBroker.java
@@ -57,6 +57,8 @@ public interface DatacenterBroker extends SimEntity {
      */
     double DEF_VM_DESTRUCTION_DELAY = -1.0;
 
+    int DEF_CURRENT_VM_CREATION_RETRIES = 1;
+
     /**
      * Specifies that an already submitted cloudlet, which is in the
      * {@link #getCloudletWaitingList() waiting list}, must run in a specific virtual machine.
@@ -493,6 +495,12 @@ public interface DatacenterBroker extends SimEntity {
      * @param failedVmsRetryDelay
      */
     void setFailedVmsRetryDelay(double failedVmsRetryDelay);
+
+    void incrementCurrentVmCreationRetries();
+
+    void setCurrentVmCreationRetries(int currentVmCreationRetries);
+
+    int getCurrentVmCreationRetries();
 
     /**
      * Checks if the broker must be shut down after becoming idle.

--- a/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBroker.java
+++ b/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBroker.java
@@ -449,7 +449,7 @@ public interface DatacenterBroker extends SimEntity {
      *
      * @param <T> the class of VMs inside the list
      * @return the list of failed VMs
-     * @see VmCreationRetry#setFailedVmsRetryDelay(double)
+     * @see VmCreationRetry#setDelay(double)
      */
     <T extends Vm> List<T> getVmFailedList();
 
@@ -465,7 +465,9 @@ public interface DatacenterBroker extends SimEntity {
      */
     DatacenterBroker setShutdownWhenIdle(boolean shutdownWhenIdle);
 
+    /**
+     * Gets the object that keeps track of number of VM creation retries sent by the broker.
+     * @return
+     */
     VmCreationRetry getVmCreationRetry();
-
-    void setVmCreationRetry(VmCreationRetry vmCreationRetry);
 }

--- a/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBroker.java
+++ b/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBroker.java
@@ -449,7 +449,7 @@ public interface DatacenterBroker extends SimEntity {
      *
      * @param <T> the class of VMs inside the list
      * @return the list of failed VMs
-     * @see VmCreationRetry#setDelay(double)
+     * @see VmCreation#setRetryDelay(double)
      */
     <T extends Vm> List<T> getVmFailedList();
 
@@ -469,5 +469,5 @@ public interface DatacenterBroker extends SimEntity {
      * Gets the object that keeps track of number of VM creation retries sent by the broker.
      * @return
      */
-    VmCreationRetry getVmCreationRetry();
+    VmCreation getVmCreationRetry();
 }

--- a/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBroker.java
+++ b/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBroker.java
@@ -466,8 +466,9 @@ public interface DatacenterBroker extends SimEntity {
     DatacenterBroker setShutdownWhenIdle(boolean shutdownWhenIdle);
 
     /**
-     * Gets the object that keeps track of number of VM creation retries sent by the broker.
+     * Gets the object that keeps track of number of VM creation retries sent by the broker
+     * and enables configuring creation retries.
      * @return
      */
-    VmCreation getVmCreationRetry();
+    VmCreation getVmCreation();
 }

--- a/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerAbstract.java
+++ b/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerAbstract.java
@@ -1303,7 +1303,7 @@ public abstract class DatacenterBrokerAbstract extends CloudSimEntity implements
     }
 
     @Override
-    public VmCreation getVmCreationRetry() {
+    public VmCreation getVmCreation() {
         return vmCreation;
     }
 }

--- a/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerAbstract.java
+++ b/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerAbstract.java
@@ -76,6 +76,7 @@ public abstract class DatacenterBrokerAbstract extends CloudSimEntity implements
 
     private VmCreationRetry vmCreationRetry;
 
+    /** @see #getVmFailedList() */
     private final List<Vm> vmFailedList;
 
     /** @see #getVmWaitingList() */

--- a/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerNull.java
+++ b/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerNull.java
@@ -82,8 +82,7 @@ final class DatacenterBrokerNull implements DatacenterBroker, SimEntityNullBase 
     @Override public DatacenterBroker setVmDestructionDelay(double delay) { return this; }
     @Override public List<Cloudlet> getCloudletSubmittedList() { return Collections.emptyList(); }
     @Override public <T extends Vm> List<T> getVmFailedList() { return Collections.emptyList(); }
-    @Override public VmCreationRetry getVmCreationRetry() { return new VmCreationRetry(); }
-    @Override public void setVmCreationRetry(VmCreationRetry vmCreationRetry) {/**/}
+    @Override public VmCreationRetry getVmCreationRetry() { return VmCreationRetry.ofZero(); }
     @Override public boolean isShutdownWhenIdle() { return false; }
     @Override public DatacenterBroker setShutdownWhenIdle(boolean shutdownWhenIdle) { return this; }
     @Override public DatacenterBroker setVmComparator(Comparator<Vm> comparator) { return this; }

--- a/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerNull.java
+++ b/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerNull.java
@@ -82,7 +82,7 @@ final class DatacenterBrokerNull implements DatacenterBroker, SimEntityNullBase 
     @Override public DatacenterBroker setVmDestructionDelay(double delay) { return this; }
     @Override public List<Cloudlet> getCloudletSubmittedList() { return Collections.emptyList(); }
     @Override public <T extends Vm> List<T> getVmFailedList() { return Collections.emptyList(); }
-    @Override public VmCreationRetry getVmCreationRetry() { return VmCreationRetry.ofZero(); }
+    @Override public VmCreation getVmCreationRetry() { return VmCreation.ofZero(); }
     @Override public boolean isShutdownWhenIdle() { return false; }
     @Override public DatacenterBroker setShutdownWhenIdle(boolean shutdownWhenIdle) { return this; }
     @Override public DatacenterBroker setVmComparator(Comparator<Vm> comparator) { return this; }

--- a/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerNull.java
+++ b/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerNull.java
@@ -84,6 +84,9 @@ final class DatacenterBrokerNull implements DatacenterBroker, SimEntityNullBase 
     @Override public <T extends Vm> List<T> getVmFailedList() { return Collections.emptyList(); }
     @Override public boolean isRetryFailedVms() { return false; }
     @Override public double getFailedVmsRetryDelay() { return 0; }
+    @Override public void incrementCurrentVmCreationRetries() {/**/};
+    @Override public int getCurrentVmCreationRetries() { return 1; }
+    @Override public void setCurrentVmCreationRetries(int currentVmCreationRetries) {/**/}
     @Override public void setFailedVmsRetryDelay(double failedVmsRetryDelay) {/**/}
     @Override public boolean isShutdownWhenIdle() { return false; }
     @Override public DatacenterBroker setShutdownWhenIdle(boolean shutdownWhenIdle) { return this; }

--- a/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerNull.java
+++ b/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerNull.java
@@ -82,7 +82,7 @@ final class DatacenterBrokerNull implements DatacenterBroker, SimEntityNullBase 
     @Override public DatacenterBroker setVmDestructionDelay(double delay) { return this; }
     @Override public List<Cloudlet> getCloudletSubmittedList() { return Collections.emptyList(); }
     @Override public <T extends Vm> List<T> getVmFailedList() { return Collections.emptyList(); }
-    @Override public VmCreation getVmCreationRetry() { return VmCreation.ofZero(); }
+    @Override public VmCreation getVmCreation() { return VmCreation.ofZero(); }
     @Override public boolean isShutdownWhenIdle() { return false; }
     @Override public DatacenterBroker setShutdownWhenIdle(boolean shutdownWhenIdle) { return this; }
     @Override public DatacenterBroker setVmComparator(Comparator<Vm> comparator) { return this; }

--- a/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerNull.java
+++ b/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerNull.java
@@ -82,12 +82,8 @@ final class DatacenterBrokerNull implements DatacenterBroker, SimEntityNullBase 
     @Override public DatacenterBroker setVmDestructionDelay(double delay) { return this; }
     @Override public List<Cloudlet> getCloudletSubmittedList() { return Collections.emptyList(); }
     @Override public <T extends Vm> List<T> getVmFailedList() { return Collections.emptyList(); }
-    @Override public boolean isRetryFailedVms() { return false; }
-    @Override public double getFailedVmsRetryDelay() { return 0; }
-    @Override public void incrementCurrentVmCreationRetries() {/**/};
-    @Override public int getCurrentVmCreationRetries() { return 1; }
-    @Override public void setCurrentVmCreationRetries(int currentVmCreationRetries) {/**/}
-    @Override public void setFailedVmsRetryDelay(double failedVmsRetryDelay) {/**/}
+    @Override public VmCreationRetry getVmCreationRetry() { return new VmCreationRetry(); }
+    @Override public void setVmCreationRetry(VmCreationRetry vmCreationRetry) {/**/}
     @Override public boolean isShutdownWhenIdle() { return false; }
     @Override public DatacenterBroker setShutdownWhenIdle(boolean shutdownWhenIdle) { return this; }
     @Override public DatacenterBroker setVmComparator(Comparator<Vm> comparator) { return this; }

--- a/src/main/java/org/cloudbus/cloudsim/brokers/VmCreation.java
+++ b/src/main/java/org/cloudbus/cloudsim/brokers/VmCreation.java
@@ -27,7 +27,8 @@ import org.cloudbus.cloudsim.vms.Vm;
 import org.cloudsimplus.listeners.EventListener;
 
 /**
- * Keeps track of number of VM creation requests and retries sent by a {@link DatacenterBroker}.
+ * Keeps track of number of VM creation requests and retries sent by a {@link DatacenterBroker}
+ * and enables configuring creation retries.
  * VM creation fails when the broker can't find a suitable Host for placement.
  *
  * @author Manoel Campos da Silva Filho

--- a/src/main/java/org/cloudbus/cloudsim/brokers/VmCreation.java
+++ b/src/main/java/org/cloudbus/cloudsim/brokers/VmCreation.java
@@ -1,3 +1,26 @@
+/*
+ * CloudSim Plus: A modern, highly-extensible and easier-to-use Framework for
+ * Modeling and Simulation of Cloud Computing Infrastructures and Services.
+ * http://cloudsimplus.org
+ *
+ *     Copyright (C) 2015-2021 Universidade da Beira Interior (UBI, Portugal) and
+ *     the Instituto Federal de Educação Ciência e Tecnologia do Tocantins (IFTO, Brazil).
+ *
+ *     This file is part of CloudSim Plus.
+ *
+ *     CloudSim Plus is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     CloudSim Plus is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with CloudSim Plus. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.cloudbus.cloudsim.brokers;
 
 import org.cloudbus.cloudsim.vms.Vm;

--- a/src/main/java/org/cloudbus/cloudsim/brokers/VmCreation.java
+++ b/src/main/java/org/cloudbus/cloudsim/brokers/VmCreation.java
@@ -121,6 +121,7 @@ public class VmCreation {
     /**
      * Gets the maximum number of times the broker will try to find a host to create (place) the VM.
      * @return
+     * @see #getRetries()
      */
     public int getMaxRetries() {
         return maxRetries;
@@ -153,6 +154,7 @@ public class VmCreation {
     /**
      * Gets the current number of times failed VMs were tried to be recreated.
      * @return
+     * @see #getMaxRetries()
      */
     public int getRetries() {
         return retries;

--- a/src/main/java/org/cloudbus/cloudsim/brokers/VmCreation.java
+++ b/src/main/java/org/cloudbus/cloudsim/brokers/VmCreation.java
@@ -47,8 +47,8 @@ public class VmCreation {
     /** @see #getMaxRetries() */
     private int maxRetries;
 
-    /** @see #getCurrentRetries() */
-    private int currentRetries;
+    /** @see #getRetries() */
+    private int retries;
 
     /** @see #getCreationRequests() */
     private int creationRequests;
@@ -140,22 +140,22 @@ public class VmCreation {
      * @return
      */
     public boolean isRetryFailedVms() {
-        return retryDelay > 0 && currentRetries < maxRetries;
+        return retryDelay > 0 && retries < maxRetries;
     }
 
     /**
      * Increments the current number of times failed VMs were tried to be recreated.
      */
     public void incCurrentRetries() {
-        this.currentRetries++;
+        this.retries++;
     }
 
     /**
      * Gets the current number of times failed VMs were tried to be recreated.
      * @return
      */
-    public int getCurrentRetries() {
-        return currentRetries;
+    public int getRetries() {
+        return retries;
     }
 
     /**
@@ -172,7 +172,7 @@ public class VmCreation {
      * @see #incCurrentRetries()
      */
     public void resetCurrentRetries() {
-        this.currentRetries = DEF_CURRENT_VM_CREATION_RETRIES;
+        this.retries = DEF_CURRENT_VM_CREATION_RETRIES;
     }
 
     /**

--- a/src/main/java/org/cloudbus/cloudsim/brokers/VmCreation.java
+++ b/src/main/java/org/cloudbus/cloudsim/brokers/VmCreation.java
@@ -4,9 +4,8 @@ import org.cloudbus.cloudsim.vms.Vm;
 import org.cloudsimplus.listeners.EventListener;
 
 /**
- * Keeps track of number of VM creation retries sent by a {@link DatacenterBroker}.
- * VM creation fails when the broker can't find a suitable Host
- * for VM placement.
+ * Keeps track of number of VM creation requests and retries sent by a {@link DatacenterBroker}.
+ * VM creation fails when the broker can't find a suitable Host for placement.
  *
  * @author Manoel Campos da Silva Filho
  * @author sohamchari

--- a/src/main/java/org/cloudbus/cloudsim/brokers/VmCreation.java
+++ b/src/main/java/org/cloudbus/cloudsim/brokers/VmCreation.java
@@ -12,15 +12,15 @@ import org.cloudsimplus.listeners.EventListener;
  * @author sohamchari
  * @since CloudSim Plus 7.3.1
  */
-public class VmCreationRetry {
+public class VmCreation {
 
     /**
      * Default number of times the broker will try to recreated failed VMs.
      */
     public static final int DEF_CURRENT_VM_CREATION_RETRIES = 5;
 
-    /** @see #getDelay() */
-    private double delay;
+    /** @see #getRetryDelay() */
+    private double retryDelay;
 
     /** @see #getMaxRetries() */
     private int maxRetries;
@@ -34,19 +34,19 @@ public class VmCreationRetry {
     /**
      * Creates an object with default values.
      */
-    public VmCreationRetry() {
-        this.delay = 5;
+    public VmCreation() {
+        this.retryDelay = 5;
         this.maxRetries = DEF_CURRENT_VM_CREATION_RETRIES;
     }
 
     /**
      * Creates an object with the given values for the attributes.
-     * @param delay a delay (in seconds) for the broker to retry allocating VMs
+     * @param retryDelay a delay (in seconds) for the broker to retry allocating VMs
      *                            that couldn't be placed due to lack of suitable active Hosts.
      * @param maxRetries the maximum number of times the broker will try to find a host to create (place) the VM.
      */
-    public VmCreationRetry(final double delay, final int maxRetries) {
-        this.delay = delay;
+    public VmCreation(final double retryDelay, final int maxRetries) {
+        this.retryDelay = retryDelay;
         this.maxRetries = maxRetries;
     }
 
@@ -54,8 +54,8 @@ public class VmCreationRetry {
      * Creates an object with all attributes equal to zero.
      * @return
      */
-    public static VmCreationRetry ofZero(){
-        return new VmCreationRetry(0, 0);
+    public static VmCreation ofZero(){
+        return new VmCreation(0, 0);
     }
 
     /**
@@ -73,8 +73,8 @@ public class VmCreationRetry {
      *  it will be notified about the failure.</li>
      * </ul>
      */
-    public double getDelay() {
-        return delay;
+    public double getRetryDelay() {
+        return retryDelay;
     }
 
     /**
@@ -90,10 +90,10 @@ public class VmCreationRetry {
      *  If the VM has an {@link Vm#addOnCreationFailureListener(EventListener) OnCreationFailureListener},
      *  it will be notified about the failure.</li>
      * </ul>
-     * @param delay the value to set
+     * @param retryDelay the value to set
      */
-    public void setDelay(final double delay) {
-        this.delay = delay;
+    public void setRetryDelay(final double retryDelay) {
+        this.retryDelay = retryDelay;
     }
 
     /**
@@ -118,13 +118,13 @@ public class VmCreationRetry {
      * @return
      */
     public boolean isRetryFailedVms() {
-        return delay > 0 && currentRetries < maxRetries;
+        return retryDelay > 0 && currentRetries < maxRetries;
     }
 
     /**
      * Increments the current number of times failed VMs were tried to be recreated.
      */
-    public void incCurrentVmCreationRetries() {
+    public void incCurrentRetries() {
         this.currentRetries++;
     }
 
@@ -147,18 +147,18 @@ public class VmCreationRetry {
     /**
      * Resets the number of VM creation requests to the {@link #DEF_CURRENT_VM_CREATION_RETRIES default number}.
      *
-     * @see #incCurrentVmCreationRetries()
+     * @see #incCurrentRetries()
      */
-    public void resetCurrentVmCreationRetries() {
+    public void resetCurrentRetries() {
         this.currentRetries = DEF_CURRENT_VM_CREATION_RETRIES;
     }
 
     /**
      * Increments/decrements the number of VM creation requests.
      * @param value the value to increment/decrement
-     * @see #resetCurrentVmCreationRetries()
+     * @see #resetCurrentRetries()
      */
-    public void incVmCreationRequests(final int value) {
+    public void incCreationRequests(final int value) {
         this.creationRequests += value;
     }
 }

--- a/src/main/java/org/cloudbus/cloudsim/brokers/VmCreationRetry.java
+++ b/src/main/java/org/cloudbus/cloudsim/brokers/VmCreationRetry.java
@@ -5,7 +5,7 @@ import org.cloudsimplus.listeners.EventListener;
 
 public class VmCreationRetry {
 
-    public static int DEF_CURRENT_VM_CREATION_RETRIES = 1;
+    public static final int DEF_CURRENT_VM_CREATION_RETRIES = 1;
 
     private double failedVmsRetryDelay;
 

--- a/src/main/java/org/cloudbus/cloudsim/brokers/VmCreationRetry.java
+++ b/src/main/java/org/cloudbus/cloudsim/brokers/VmCreationRetry.java
@@ -3,24 +3,59 @@ package org.cloudbus.cloudsim.brokers;
 import org.cloudbus.cloudsim.vms.Vm;
 import org.cloudsimplus.listeners.EventListener;
 
+/**
+ * Keeps track of number of VM creation retries sent by a {@link DatacenterBroker}.
+ * VM creation fails when the broker can't find a suitable Host
+ * for VM placement.
+ *
+ * @author Manoel Campos da Silva Filho
+ * @author sohamchari
+ * @since CloudSim Plus 7.3.1
+ */
 public class VmCreationRetry {
 
-    public static final int DEF_CURRENT_VM_CREATION_RETRIES = 1;
+    /**
+     * Default number of times the broker will try to recreated failed VMs.
+     */
+    public static final int DEF_CURRENT_VM_CREATION_RETRIES = 5;
 
-    private double failedVmsRetryDelay;
+    /** @see #getDelay() */
+    private double delay;
 
-    private int maxVmCreationRetries;
+    /** @see #getMaxRetries() */
+    private int maxRetries;
 
-    private int currentVmCreationRetries;
+    /** @see #getCurrentRetries() */
+    private int currentRetries;
 
-    /** @see #getVmCreationRequests() */
-    private int vmCreationRequests;
+    /** @see #getCreationRequests() */
+    private int creationRequests;
 
+    /**
+     * Creates an object with default values.
+     */
     public VmCreationRetry() {
-        this.failedVmsRetryDelay = 5;
-        this.currentVmCreationRetries = 1;
-        this.maxVmCreationRetries = (int) failedVmsRetryDelay;
-        this.vmCreationRequests = 0;
+        this.delay = 5;
+        this.maxRetries = DEF_CURRENT_VM_CREATION_RETRIES;
+    }
+
+    /**
+     * Creates an object with the given values for the attributes.
+     * @param delay a delay (in seconds) for the broker to retry allocating VMs
+     *                            that couldn't be placed due to lack of suitable active Hosts.
+     * @param maxRetries the maximum number of times the broker will try to find a host to create (place) the VM.
+     */
+    public VmCreationRetry(final double delay, final int maxRetries) {
+        this.delay = delay;
+        this.maxRetries = maxRetries;
+    }
+
+    /**
+     * Creates an object with all attributes equal to zero.
+     * @return
+     */
+    public static VmCreationRetry ofZero(){
+        return new VmCreationRetry(0, 0);
     }
 
     /**
@@ -38,8 +73,8 @@ public class VmCreationRetry {
      *  it will be notified about the failure.</li>
      * </ul>
      */
-    public double getFailedVmsRetryDelay() {
-        return failedVmsRetryDelay;
+    public double getDelay() {
+        return delay;
     }
 
     /**
@@ -55,18 +90,26 @@ public class VmCreationRetry {
      *  If the VM has an {@link Vm#addOnCreationFailureListener(EventListener) OnCreationFailureListener},
      *  it will be notified about the failure.</li>
      * </ul>
-     * @param failedVmsRetryDelay
+     * @param delay the value to set
      */
-    public void setFailedVmsRetryDelay(double failedVmsRetryDelay) {
-        this.failedVmsRetryDelay = failedVmsRetryDelay;
+    public void setDelay(final double delay) {
+        this.delay = delay;
     }
 
-    public int getMaxVmCreationRetries() {
-        return maxVmCreationRetries;
+    /**
+     * Gets the maximum number of times the broker will try to find a host to create (place) the VM.
+     * @return
+     */
+    public int getMaxRetries() {
+        return maxRetries;
     }
 
-    public void setMaxVmCreationRetries(int maxVmCreationRetries) {
-        this.maxVmCreationRetries = maxVmCreationRetries;
+    /**
+     * Sets the maximum number of times the broker will try to find a host to create (place) the VM.
+     * @param maxRetries value to set
+     */
+    public void setMaxRetries(final int maxRetries) {
+        this.maxRetries = maxRetries;
     }
 
     /**
@@ -75,32 +118,47 @@ public class VmCreationRetry {
      * @return
      */
     public boolean isRetryFailedVms() {
-        return failedVmsRetryDelay > 0 && currentVmCreationRetries < maxVmCreationRetries;
-    }
-
-    public void incrementCurrentVmCreationRetries() {
-        this.currentVmCreationRetries++;
-    }
-
-    public int getCurrentVmCreationRetries() {
-        return currentVmCreationRetries;
-    }
-
-    public void setCurrentVmCreationRetries(int currentVmCreationRetries) {
-        this.currentVmCreationRetries = currentVmCreationRetries;
+        return delay > 0 && currentRetries < maxRetries;
     }
 
     /**
-     * Gets the number of VM creation requests.
-     *
-     * @return the number of VM creation requests
+     * Increments the current number of times failed VMs were tried to be recreated.
      */
-    public int getVmCreationRequests() {
-        return vmCreationRequests;
+    public void incCurrentVmCreationRetries() {
+        this.currentRetries++;
     }
 
-    public void setVmCreationRequests(int vmCreationRequests) {
-        this.vmCreationRequests = vmCreationRequests;
+    /**
+     * Gets the current number of times failed VMs were tried to be recreated.
+     * @return
+     */
+    public int getCurrentRetries() {
+        return currentRetries;
     }
 
+    /**
+     * Gets the number of VM creation requests considering all submitted VMs.
+     * @return
+     */
+    public int getCreationRequests() {
+        return creationRequests;
+    }
+
+    /**
+     * Resets the number of VM creation requests to the {@link #DEF_CURRENT_VM_CREATION_RETRIES default number}.
+     *
+     * @see #incCurrentVmCreationRetries()
+     */
+    public void resetCurrentVmCreationRetries() {
+        this.currentRetries = DEF_CURRENT_VM_CREATION_RETRIES;
+    }
+
+    /**
+     * Increments/decrements the number of VM creation requests.
+     * @param value the value to increment/decrement
+     * @see #resetCurrentVmCreationRetries()
+     */
+    public void incVmCreationRequests(final int value) {
+        this.creationRequests += value;
+    }
 }

--- a/src/main/java/org/cloudbus/cloudsim/brokers/VmCreationRetry.java
+++ b/src/main/java/org/cloudbus/cloudsim/brokers/VmCreationRetry.java
@@ -1,0 +1,106 @@
+package org.cloudbus.cloudsim.brokers;
+
+import org.cloudbus.cloudsim.vms.Vm;
+import org.cloudsimplus.listeners.EventListener;
+
+public class VmCreationRetry {
+
+    public static int DEF_CURRENT_VM_CREATION_RETRIES = 1;
+
+    private double failedVmsRetryDelay;
+
+    private int maxVmCreationRetries;
+
+    private int currentVmCreationRetries;
+
+    /** @see #getVmCreationRequests() */
+    private int vmCreationRequests;
+
+    public VmCreationRetry() {
+        this.failedVmsRetryDelay = 5;
+        this.currentVmCreationRetries = 1;
+        this.maxVmCreationRetries = (int) failedVmsRetryDelay;
+        this.vmCreationRequests = 0;
+    }
+
+    /**
+     * Gets a delay (in seconds) for the broker to retry allocating VMs
+     * that couldn't be placed due to lack of suitable active Hosts.
+     *
+     * @return
+     * <ul>
+     *  <li>a value larger than zero to indicate the broker will retry
+     *  to place failed VM as soon as new VMs or Cloudlets
+     *  are submitted or after the given delay.</li>
+     *  <li>otherwise, to indicate failed VMs will be just added to the
+     *  {@link DatacenterBroker#getVmFailedList()} and the user simulation have to deal with it.
+     *  If the VM has an {@link Vm#addOnCreationFailureListener(EventListener) OnCreationFailureListener},
+     *  it will be notified about the failure.</li>
+     * </ul>
+     */
+    public double getFailedVmsRetryDelay() {
+        return failedVmsRetryDelay;
+    }
+
+    /**
+     * Sets a delay (in seconds) for the broker to retry allocating VMs
+     * that couldn't be placed due to lack of suitable active Hosts.
+     *
+     * Setting the attribute as:
+     * <ul>
+     *  <li>larger than zero, the broker will retry to place failed VM as soon as new VMs or Cloudlets
+     *  are submitted or after the given delay.</li>
+     *  <li>otherwise, failed VMs will be just added to the {@link DatacenterBroker#getVmFailedList()}
+     *  and the user simulation have to deal with it.
+     *  If the VM has an {@link Vm#addOnCreationFailureListener(EventListener) OnCreationFailureListener},
+     *  it will be notified about the failure.</li>
+     * </ul>
+     * @param failedVmsRetryDelay
+     */
+    public void setFailedVmsRetryDelay(double failedVmsRetryDelay) {
+        this.failedVmsRetryDelay = failedVmsRetryDelay;
+    }
+
+    public int getMaxVmCreationRetries() {
+        return maxVmCreationRetries;
+    }
+
+    public void setMaxVmCreationRetries(int maxVmCreationRetries) {
+        this.maxVmCreationRetries = maxVmCreationRetries;
+    }
+
+    /**
+     * Checks if the broker has to retry allocating VMs
+     * that couldn't be placed due to lack of suitable Hosts.
+     * @return
+     */
+    public boolean isRetryFailedVms() {
+        return failedVmsRetryDelay > 0 && currentVmCreationRetries < maxVmCreationRetries;
+    }
+
+    public void incrementCurrentVmCreationRetries() {
+        this.currentVmCreationRetries++;
+    }
+
+    public int getCurrentVmCreationRetries() {
+        return currentVmCreationRetries;
+    }
+
+    public void setCurrentVmCreationRetries(int currentVmCreationRetries) {
+        this.currentVmCreationRetries = currentVmCreationRetries;
+    }
+
+    /**
+     * Gets the number of VM creation requests.
+     *
+     * @return the number of VM creation requests
+     */
+    public int getVmCreationRequests() {
+        return vmCreationRequests;
+    }
+
+    public void setVmCreationRequests(int vmCreationRequests) {
+        this.vmCreationRequests = vmCreationRequests;
+    }
+
+}

--- a/src/test/java/org/cloudsimplus/integrationtests/VmCreationFailureIntegrationTest.java
+++ b/src/test/java/org/cloudsimplus/integrationtests/VmCreationFailureIntegrationTest.java
@@ -198,7 +198,7 @@ public final class VmCreationFailureIntegrationTest {
 
         final BrokerBuilderDecorator brokerBuilder =
             scenario.getBrokerBuilder()
-                    .create(b -> b.getVmCreationRetry().setDelay(-1));
+                    .create(b -> b.getVmCreationRetry().setRetryDelay(-1));
 
         brokerBuilder.getVmBuilder()
                 .setPes(1)

--- a/src/test/java/org/cloudsimplus/integrationtests/VmCreationFailureIntegrationTest.java
+++ b/src/test/java/org/cloudsimplus/integrationtests/VmCreationFailureIntegrationTest.java
@@ -198,7 +198,7 @@ public final class VmCreationFailureIntegrationTest {
 
         final BrokerBuilderDecorator brokerBuilder =
             scenario.getBrokerBuilder()
-                    .create(b -> b.getVmCreationRetry().setFailedVmsRetryDelay(-1));
+                    .create(b -> b.getVmCreationRetry().setDelay(-1));
 
         brokerBuilder.getVmBuilder()
                 .setPes(1)

--- a/src/test/java/org/cloudsimplus/integrationtests/VmCreationFailureIntegrationTest.java
+++ b/src/test/java/org/cloudsimplus/integrationtests/VmCreationFailureIntegrationTest.java
@@ -198,7 +198,7 @@ public final class VmCreationFailureIntegrationTest {
 
         final BrokerBuilderDecorator brokerBuilder =
             scenario.getBrokerBuilder()
-                    .create(b -> b.getVmCreationRetry().setRetryDelay(-1));
+                    .create(b -> b.getVmCreation().setRetryDelay(-1));
 
         brokerBuilder.getVmBuilder()
                 .setPes(1)

--- a/src/test/java/org/cloudsimplus/integrationtests/VmCreationFailureIntegrationTest.java
+++ b/src/test/java/org/cloudsimplus/integrationtests/VmCreationFailureIntegrationTest.java
@@ -198,7 +198,7 @@ public final class VmCreationFailureIntegrationTest {
 
         final BrokerBuilderDecorator brokerBuilder =
             scenario.getBrokerBuilder()
-                    .create(b -> b.setFailedVmsRetryDelay(-1));
+                    .create(b -> b.getVmCreationRetry().setFailedVmsRetryDelay(-1));
 
         brokerBuilder.getVmBuilder()
                 .setPes(1)


### PR DESCRIPTION
# Fix #349

2 New attributes `maxVmCreationRetries` and `currentVmCreationRetries` are created to keep track of the number of retry requests sent in DataBroker.java. The`maxVmCreationRetries` conforms with `failedVmsRetryDelay` and every time a new creation retry request is sent `currentVmCreationRetries` is incremented.

Once all the VMs are allocated and `vmWaitingList` is empty, `currentVmCreationRetries` is set to default to the value of 1.