### PR TITLE
Add new methods for formatting to the TableBuilder / Fixes 

### DIFF
--- a/src/main/java/org/cloudsimplus/builders/tables/AbstractTable.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/AbstractTable.java
@@ -209,32 +209,37 @@ public abstract class AbstractTable implements Table {
     }
 
     @Override
-    public final TableColumn newColumn(final String columnTitle) {
-        return addColumn(getColumns().size(), columnTitle);
+    public final TableColumn newColumn(final String title, final String subTitle) {
+        return newColumn(title).setSubTitle(subTitle);
     }
 
     @Override
-    public final TableColumn addColumn(final String columnTitle, final String columnSubTitle) {
-        return newColumn(columnTitle).setSubTitle(columnSubTitle);
+    public final TableColumn newColumn(final String title) {
+        return newColumn(title, "", "");
     }
 
-    @Override
-    public TableColumn addColumn(final String columnTitle, final String columnSubTitle, final String format) {
-        return addColumn(columnTitle, columnSubTitle).setFormat(format);
+    /**
+     * Adds a column to the end of the table.
+     * @param column the column to add
+     * @return
+     */
+    protected final TableColumn addColumn(final TableColumn column) {
+        return addColumn(column, columns.size());
     }
 
-    @Override
-    public final TableColumn addColumn(final int index, final TableColumn column) {
+    /**
+     * Adds a column at a given position of the table.
+     *
+     * @param column the column to add
+     * @param index  the position in the table to add the column
+     * @return
+     */
+    protected final TableColumn addColumn(final TableColumn column, final int index) {
         column.setTable(this);
         if(index > colCount())
             columns.add(column);
         else columns.add(index, column);
         return column;
-    }
-
-    @Override
-    public final TableColumn addColumn(final TableColumn column) {
-        return addColumn(columns.size(), column);
     }
 
     /**

--- a/src/main/java/org/cloudsimplus/builders/tables/AbstractTable.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/AbstractTable.java
@@ -225,6 +225,7 @@ public abstract class AbstractTable implements Table {
 
     @Override
     public final TableColumn addColumn(final int index, final TableColumn column) {
+        column.setTable(this);
         columns.add(index, column);
         return column;
     }

--- a/src/main/java/org/cloudsimplus/builders/tables/AbstractTable.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/AbstractTable.java
@@ -203,19 +203,19 @@ public abstract class AbstractTable implements Table {
     @Override
     public final Table addColumnList(final String... columnTitles) {
         for(final String column: columnTitles){
-            addColumn(column);
+            newColumn(column);
         }
         return this;
     }
 
     @Override
-    public final TableColumn addColumn(final String columnTitle) {
+    public final TableColumn newColumn(final String columnTitle) {
         return addColumn(getColumns().size(), columnTitle);
     }
 
     @Override
     public final TableColumn addColumn(final String columnTitle, final String columnSubTitle) {
-        return addColumn(columnTitle).setSubTitle(columnSubTitle);
+        return newColumn(columnTitle).setSubTitle(columnSubTitle);
     }
 
     @Override
@@ -226,7 +226,9 @@ public abstract class AbstractTable implements Table {
     @Override
     public final TableColumn addColumn(final int index, final TableColumn column) {
         column.setTable(this);
-        columns.add(index, column);
+        if(index > colCount())
+            columns.add(column);
+        else columns.add(index, column);
         return column;
     }
 

--- a/src/main/java/org/cloudsimplus/builders/tables/AbstractTable.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/AbstractTable.java
@@ -78,6 +78,11 @@ public abstract class AbstractTable implements Table {
     }
 
     @Override
+    public int colCount() {
+        return columns.size();
+    }
+
+    @Override
     public String getTitle() {
         return title;
     }

--- a/src/main/java/org/cloudsimplus/builders/tables/AbstractTableColumn.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/AbstractTableColumn.java
@@ -112,8 +112,8 @@ public abstract class AbstractTableColumn implements TableColumn {
     }
 
     @Override
-    public AbstractTableColumn setSubTitle(String subTitle) {
-        this.subTitle = subTitle;
+    public AbstractTableColumn setSubTitle(final String subTitle) {
+        this.subTitle = requireNonNullElse(subTitle, "");
         return this;
     }
 

--- a/src/main/java/org/cloudsimplus/builders/tables/AbstractTableColumn.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/AbstractTableColumn.java
@@ -99,7 +99,17 @@ public abstract class AbstractTableColumn implements TableColumn {
 
     @Override
     public boolean matchTitle(final String title) {
-        return this.title.trim().equals(requireNonNullElse(title, ""));
+        return matchString(this.title, title);
+    }
+
+    /**
+     * Checks if two Strings match, ignoring whitespaces at left and right (padding).
+     * @param text1 one String to compare
+     * @param text2 other String to compare
+     * @return true if the two strings are equals, ignoring padding
+     */
+    private boolean matchString(final String text1, final String text2){
+        return text1.trim().equals(requireNonNullElse(text2, ""));
     }
 
     /**

--- a/src/main/java/org/cloudsimplus/builders/tables/AbstractTableColumn.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/AbstractTableColumn.java
@@ -144,7 +144,7 @@ public abstract class AbstractTableColumn implements TableColumn {
 
     @Override
     public final AbstractTableColumn setFormat(String format) {
-        this.format = format;
+        this.format = requireNonNullElse(format, "");
         return this;
     }
 

--- a/src/main/java/org/cloudsimplus/builders/tables/AbstractTableColumn.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/AbstractTableColumn.java
@@ -97,6 +97,11 @@ public abstract class AbstractTableColumn implements TableColumn {
         return this;
     }
 
+    @Override
+    public boolean matchTitle(final String title) {
+        return this.title.trim().equals(requireNonNullElse(title, ""));
+    }
+
     /**
      *
      * @return The subtitle to be displayed below the title of the column (optional).

--- a/src/main/java/org/cloudsimplus/builders/tables/AbstractTableColumn.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/AbstractTableColumn.java
@@ -60,18 +60,18 @@ public abstract class AbstractTableColumn implements TableColumn {
     }
 
     /**
-     * Creates a column with a specific title and sub-title.
+     * Creates a column with a specific title and subtitle.
      * @param title The column title.
-     * @param subTitle The column sub-title.
+     * @param subTitle The column subtitle.
      */
     public AbstractTableColumn(final String title, final String subTitle) {
         this(null, title, subTitle);
     }
 
     /**
-     * Creates a column with a specific title and sub-title for a given table.
+     * Creates a column with a specific title and subtitle for a given table.
      * @param title The column title.
-     * @param subTitle The column sub-title.
+     * @param subTitle The column subtitle.
      */
     public AbstractTableColumn(final Table table, final String title, final String subTitle) {
         this.table = table;

--- a/src/main/java/org/cloudsimplus/builders/tables/AbstractTableColumn.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/AbstractTableColumn.java
@@ -62,24 +62,24 @@ public abstract class AbstractTableColumn implements TableColumn {
     }
 
     /**
-     * Creates a column with a specific title and subtitle.
-     * @param title The column title.
-     * @param subTitle The column subtitle.
-     */
-    public AbstractTableColumn(final String title, final String subTitle) {
-        this(null, title, subTitle);
-    }
-
-    /**
      * Creates a column with a specific title and subtitle for a given table.
      * @param title The column title.
      * @param subTitle The column subtitle.
      */
     public AbstractTableColumn(final Table table, final String title, final String subTitle) {
+        this(title, subTitle);
         this.table = table;
+    }
+
+    /**
+     * Creates a column with a specific title and subtitle.
+     * @param title The column title.
+     * @param subTitle The column subtitle.
+     */
+    public AbstractTableColumn(final String title, final String subTitle) {
         this.title = title;
-        this.setFormat("");
         this.subTitle = subTitle;
+        this.setFormat("");
     }
 
     /**
@@ -202,12 +202,8 @@ public abstract class AbstractTableColumn implements TableColumn {
         return generateHeader(subTitle);
     }
 
-    /**
-     *
-     * @return The index of the current column into the
-     * column list of the {@link #getTable() Table}.
-     */
-    protected int getIndex() {
+    @Override
+    public int getIndex() {
         return table.getColumns().indexOf(this);
     }
 

--- a/src/main/java/org/cloudsimplus/builders/tables/AbstractTableColumn.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/AbstractTableColumn.java
@@ -98,6 +98,11 @@ public abstract class AbstractTableColumn implements TableColumn {
     }
 
     @Override
+    public boolean matchSubTitle(final String subtitle) {
+        return matchString(this.subTitle, subtitle);
+    }
+
+    @Override
     public boolean matchTitle(final String title) {
         return matchString(this.title, title);
     }

--- a/src/main/java/org/cloudsimplus/builders/tables/AbstractTableColumn.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/AbstractTableColumn.java
@@ -62,6 +62,18 @@ public abstract class AbstractTableColumn implements TableColumn {
     }
 
     /**
+     * Creates a column with a specific title, subtitle and format.
+     * @param title The column title.
+     * @param subTitle The column subtitle.
+     * @param format The column format.
+     */
+    public AbstractTableColumn(final String title, final String subTitle, final String format) {
+        this.title = title;
+        this.subTitle = subTitle;
+        this.setFormat(format);
+    }
+
+    /**
      * Creates a column with a specific title and subtitle for a given table.
      * @param title The column title.
      * @param subTitle The column subtitle.
@@ -77,9 +89,7 @@ public abstract class AbstractTableColumn implements TableColumn {
      * @param subTitle The column subtitle.
      */
     public AbstractTableColumn(final String title, final String subTitle) {
-        this.title = title;
-        this.subTitle = subTitle;
-        this.setFormat("");
+        this(title, subTitle, "");
     }
 
     /**

--- a/src/main/java/org/cloudsimplus/builders/tables/AbstractTableColumn.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/AbstractTableColumn.java
@@ -25,6 +25,8 @@ package org.cloudsimplus.builders.tables;
 
 import org.apache.commons.lang3.StringUtils;
 
+import static java.util.Objects.requireNonNullElse;
+
 /**
  * A column of a table to be generated using a {@link Table} class.
  * @author Manoel Campos da Silva Filho
@@ -90,8 +92,8 @@ public abstract class AbstractTableColumn implements TableColumn {
     }
 
     @Override
-    public AbstractTableColumn setTitle(String title) {
-        this.title = title;
+    public AbstractTableColumn setTitle(final String title) {
+        this.title = requireNonNullElse(title, "");
         return this;
     }
 

--- a/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
@@ -97,15 +97,15 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
      */
     private List<TableColumn> peColumnList;
     
-    
-    
-
-    @Override
-    protected void createTableColumns() {
+    /**
+     *  Initialize lists and default formats.
+     *  This has to be done here because the createTableColumns() function gets executed by the superclass before these class
+     *  variables would normally get initialized if they were assigned the normal way (which is after the constructor of the superclass has finished).
+     *  This function ensures that they are already present for createTableColumns().
+     */
+    private void initializeFormattingSettings() {
     	
-    	// Initialize lists and default formats.
-    	// This has to be done here because this function gets executed by the superclass
-    	// before these class variables would normally get initialized (which is after the constructor of the superclass has finished).
+    	
     	
     	timeColumnList = new ArrayList<TableColumn>();
     	lengthColumnList = new ArrayList<TableColumn>();
@@ -116,6 +116,12 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
         lengthFormat = "%d";
         idFormat = "%d";
         peFormat = "%d";
+    }
+
+    @Override
+    protected void createTableColumns() {
+    	
+    	initializeFormattingSettings();
         
         // Set up all table fields
         
@@ -239,11 +245,12 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
         /*If the given time minus the start time is less than 1,
         * it means the execution time was less than 1 second.
         * This way, it can't be round.*/
-        if(time - cloudlet.getExecStartTime() < 1){
+        /*if(time - cloudlet.getExecStartTime() < 1){
             return time;
         }
 
         final double startFraction = cloudlet.getExecStartTime() - (int) cloudlet.getExecStartTime();
-        return Math.round(time - startFraction);
+        return Math.round(time - startFraction);*/
+    	return time;
     }
 }

--- a/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
@@ -184,6 +184,9 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
         addColDataFunction(execTimeCol, cl -> roundTime(cl, cl.getActualCpuTime()));
     }
     
+    // TODO: Just setting the variables is not enough.
+    // The setters need to iterate through their respective lists to actually adjust the formatting on the individual columns.
+    
     public CloudletsTableBuilder setTimeFormat(String format) {
     	this.timeFormat = format;
     	return this;

--- a/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
@@ -52,7 +52,7 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
 	private static final String DEFAULT_PE_FORMAT = "%d";
 
     /**
-     * Instantiates a builder to print the list of Cloudlets using the a
+     * Instantiates a builder to print the list of Cloudlets using the
      * default {@link MarkdownTable}.
      * To use a different {@link Table}, check the alternative constructors.
      *

--- a/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
@@ -104,9 +104,7 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
      *  This function ensures that they are already present for createTableColumns().
      */
     private void initializeFormattingSettings() {
-    	
-    	
-    	
+
     	timeColumnList = new ArrayList<TableColumn>();
     	lengthColumnList = new ArrayList<TableColumn>();
     	idColumnList = new ArrayList<TableColumn>();
@@ -182,12 +180,12 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
         // FinishTime
         final var finishTimeCol = getTable().addColumn("FinishTime", SECONDS).setFormat(getTimeFormat());
         timeColumnList.add(finishTimeCol);
-        addColDataFunction(finishTimeCol, cl -> roundTime(cl, cl.getFinishTime()));
+        addColDataFunction(finishTimeCol, cl -> cl.getFinishTime());
 
         // ExecTime
         final var execTimeCol = getTable().addColumn("ExecTime", SECONDS).setFormat(getTimeFormat());
         timeColumnList.add(execTimeCol);
-        addColDataFunction(execTimeCol, cl -> roundTime(cl, cl.getActualCpuTime()));
+        addColDataFunction(execTimeCol, cl ->  cl.getActualCpuTime());
     }
     
     // TODO: Just setting the variables is not enough.
@@ -229,28 +227,4 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
     	return this.idFormat;
     }
 
-    /**
-     * Rounds a given time so that decimal places are ignored.
-     * Sometimes a Cloudlet start at time 0.1 and finish at time 10.1.
-     * Previously, in such a situation, the finish time was rounded to 11 (Math.ceil),
-     * giving the wrong idea that the Cloudlet took 11 seconds to finish.
-     * This method makes some little adjustments to avoid such a precision issue.
-     *
-     * @param cloudlet the Cloudlet being printed
-     * @param time the time to round
-     * @return
-     */
-    private double roundTime(final Cloudlet cloudlet, final double time) {
-
-        /*If the given time minus the start time is less than 1,
-        * it means the execution time was less than 1 second.
-        * This way, it can't be round.*/
-        /*if(time - cloudlet.getExecStartTime() < 1){
-            return time;
-        }
-
-        final double startFraction = cloudlet.getExecStartTime() - (int) cloudlet.getExecStartTime();
-        return Math.round(time - startFraction);*/
-    	return time;
-    }
 }

--- a/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
@@ -28,10 +28,12 @@ import org.cloudbus.cloudsim.core.Identifiable;
 
 import java.util.List;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Builds a table for printing simulation results from a list of Cloudlets.
  * It defines a set of default columns but new ones can be added
- * dynamically using the {@code newColumn()} methods.
+ * dynamically using the {@code addColumn()} methods.
  *
  * <p>The basic usage of the class is by calling its constructor,
  * giving a list of Cloudlets to be printed, and then
@@ -46,10 +48,14 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
     private static final String ID = "ID";
     private static final String MI = "MI";
 
-	private static final String DEFAULT_TIME_FORMAT = "%.1f";
-	private static final String DEFAULT_LENGTH_FORMAT = "%d";
-	private static final String DEFAULT_ID_FORMAT = "%d";
-	private static final String DEFAULT_PE_FORMAT = "%d";
+    /** @see #setTimeFormat(String) */
+    private String timeFormat = "%.1f";
+    /** @see #setLengthFormat(String) */
+    private String lengthFormat = "%d";
+    /** @see #setIdFormat(String) */
+    private String idFormat = "%d";
+    /** @see #setPeFormat(String) */
+    private String peFormat = "%d";
 
     /**
      * Instantiates a builder to print the list of Cloudlets using the
@@ -75,26 +81,85 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
 
     @Override
     protected void createTableColumns() {
-        addColumn(newColumn("Cloudlet", ID), Identifiable::getId);
+        addColumn(getTable().newColumn("Cloudlet", ID), Identifiable::getId);
 
         // 1 extra space to ensure proper formatting
-        mapColDataFunction(getTable().newColumn(" Status") , cloudlet -> cloudlet.getStatus().name());
+        addColumn(getTable().newColumn(" Status") , cloudlet -> cloudlet.getStatus().name());
 
-        mapColDataFunction(addColumn("DC", ID, DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getHost().getDatacenter().getId());
+        addColumn(getTable().newColumn("DC", ID, idFormat), cloudlet -> cloudlet.getVm().getHost().getDatacenter().getId());
 
-        mapColDataFunction(addColumn("Host", ID, DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getHost().getId());
-        mapColDataFunction(addColumn("Host PEs ", CPU_CORES, DEFAULT_PE_FORMAT), cloudlet -> cloudlet.getVm().getHost().getWorkingPesNumber());
+        addColumn(getTable().newColumn("Host", ID, idFormat), cloudlet -> cloudlet.getVm().getHost().getId());
+        addColumn(getTable().newColumn("Host PEs ", CPU_CORES, peFormat), cloudlet -> cloudlet.getVm().getHost().getWorkingPesNumber());
 
-        mapColDataFunction(addColumn("VM", ID, DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getId());
+        addColumn(getTable().newColumn("VM", ID, idFormat), cloudlet -> cloudlet.getVm().getId());
 
         // 3 extra spaces to ensure proper formatting
-        mapColDataFunction(addColumn("   VM PEs", CPU_CORES, DEFAULT_PE_FORMAT), cloudlet -> cloudlet.getVm().getNumberOfPes());
-        mapColDataFunction(addColumn("CloudletLen", MI, DEFAULT_LENGTH_FORMAT), Cloudlet::getLength);
-        mapColDataFunction(addColumn("FinishedLen", MI, DEFAULT_LENGTH_FORMAT), Cloudlet::getFinishedLengthSoFar);
-        mapColDataFunction(addColumn("CloudletPEs", CPU_CORES, DEFAULT_PE_FORMAT), Cloudlet::getNumberOfPes);
-        mapColDataFunction(addColumn("StartTime", SECONDS, DEFAULT_TIME_FORMAT), Cloudlet::getExecStartTime);
-        mapColDataFunction(addColumn("FinishTime", SECONDS, DEFAULT_TIME_FORMAT), Cloudlet::getFinishTime);
-        mapColDataFunction(addColumn("ExecTime", SECONDS, DEFAULT_TIME_FORMAT), Cloudlet::getActualCpuTime);
+        addColumn(getTable().newColumn("   VM PEs", CPU_CORES, peFormat), cloudlet -> cloudlet.getVm().getNumberOfPes());
+        addColumn(getTable().newColumn("CloudletLen", MI, lengthFormat), Cloudlet::getLength);
+        addColumn(getTable().newColumn("FinishedLen", MI, lengthFormat), Cloudlet::getFinishedLengthSoFar);
+        addColumn(getTable().newColumn("CloudletPEs", CPU_CORES, peFormat), Cloudlet::getNumberOfPes);
+        addColumn(getTable().newColumn("StartTime", SECONDS, timeFormat), Cloudlet::getExecStartTime);
+        addColumn(getTable().newColumn("FinishTime", SECONDS, timeFormat), Cloudlet::getFinishTime);
+        addColumn(getTable().newColumn("ExecTime", SECONDS, timeFormat), Cloudlet::getActualCpuTime);
     }
 
+    /**
+     * Gets the format for time columns.
+     */
+    public String getTimeFormat() {
+        return timeFormat;
+    }
+
+    /**
+     * Sets the format for time columns.
+     */
+    public CloudletsTableBuilder setTimeFormat(final String timeFormat) {
+        this.timeFormat = requireNonNull(timeFormat);
+        return this;
+    }
+
+    /**
+     * Gets the format for cloudlet length columns.
+     */
+    public String getLengthFormat() {
+        return lengthFormat;
+    }
+
+    /**
+     * Sets the format for cloudlet length columns.
+     */
+    public CloudletsTableBuilder setLengthFormat(final String lengthFormat) {
+        this.lengthFormat = requireNonNull(lengthFormat);
+        return this;
+    }
+
+    /**
+     * Gets the format for ID columns.
+     */
+    public String getIdFormat() {
+        return idFormat;
+    }
+
+    /**
+     * Sets the format for ID columns.
+     */
+    public CloudletsTableBuilder setIdFormat(final String idFormat) {
+        this.idFormat = requireNonNull(idFormat);
+        return this;
+    }
+
+    /**
+     * Gets the format for columns indicating number of PEs.
+     */
+    public String getPeFormat() {
+        return peFormat;
+    }
+
+    /**
+     * Sets the format for columns indicating number of PEs.
+     */
+    public CloudletsTableBuilder setPeFormat(final String peFormat) {
+        this.peFormat = requireNonNull(peFormat);
+        return this;
+    }
 }

--- a/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
@@ -44,6 +44,7 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
     private static final String SECONDS = "Seconds";
     private static final String CPU_CORES = "CPU cores";
     private static final String ID = "ID";
+    private static final String MI = "MI";
 	
 	private static final String DEFAULT_TIME_FORMAT = "%.1f";
 	private static final String DEFAULT_LENGTH_FORMAT = "%d";
@@ -99,10 +100,10 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
         addColDataFunction(getTable().addColumn("   VM PEs", CPU_CORES,DEFAULT_PE_FORMAT), cloudlet -> cloudlet.getVm().getNumberOfPes());
         
         // CloudletLen
-        addColDataFunction(getTable().addColumn("CloudletLen", "MI",DEFAULT_LENGTH_FORMAT), Cloudlet::getLength);
+        addColDataFunction(getTable().addColumn("CloudletLen", MI,DEFAULT_LENGTH_FORMAT), Cloudlet::getLength);
         
         // FinishedLen
-        addColDataFunction(getTable().addColumn("FinishedLen", "MI",DEFAULT_LENGTH_FORMAT), Cloudlet::getFinishedLengthSoFar);
+        addColDataFunction(getTable().addColumn("FinishedLen", MI,DEFAULT_LENGTH_FORMAT), Cloudlet::getFinishedLengthSoFar);
         
         // CloudletPEs
         addColDataFunction(getTable().addColumn("CloudletPEs", CPU_CORES,DEFAULT_PE_FORMAT), Cloudlet::getNumberOfPes);

--- a/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
@@ -98,7 +98,7 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
     }
 
     private TableColumn addColumn(final String title, final String subtitle) {
-        return getTable().addColumn(title, subtitle, "");
+        return addColumn(title, subtitle, "");
     }
 
     private TableColumn addColumn(final String title, final String subtitle, final String format) {

--- a/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
@@ -31,7 +31,7 @@ import java.util.List;
 /**
  * Builds a table for printing simulation results from a list of Cloudlets.
  * It defines a set of default columns but new ones can be added
- * dynamically using the {@code addColumn()} methods.
+ * dynamically using the {@code newColumn()} methods.
  *
  * <p>The basic usage of the class is by calling its constructor,
  * giving a list of Cloudlets to be printed, and then
@@ -75,10 +75,10 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
 
     @Override
     protected void createTableColumns() {
-        mapColDataFunction(addColumn("Cloudlet", ID), Identifiable::getId);
+        addColumn(newColumn("Cloudlet", ID), Identifiable::getId);
 
         // 1 extra space to ensure proper formatting
-        mapColDataFunction(getTable().addColumn(" Status") , cloudlet -> cloudlet.getStatus().name());
+        mapColDataFunction(getTable().newColumn(" Status") , cloudlet -> cloudlet.getStatus().name());
 
         mapColDataFunction(addColumn("DC", ID, DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getHost().getDatacenter().getId());
 

--- a/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
@@ -46,10 +46,10 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
     private static final String CPU_CORES = "CPU cores";
     private static final String ID = "ID";
 	
-	private String timeFormat = "%.1f";
-	private String lengthFormat = "%d";
-	private String idFormat = "%d";
-	private String peFormat = "%d";
+	private static final String DEFAULT_TIME_FORMAT = "%.1f";
+	private static final String DEFAULT_LENGTH_FORMAT = "%d";
+	private static final String DEFAULT_ID_FORMAT = "%d";
+	private static final String DEFAULT_PE_FORMAT = "%d";
 
     /**
      * Instantiates a builder to print the list of Cloudlets using the a
@@ -72,30 +72,6 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
     public CloudletsTableBuilder(final List<? extends Cloudlet> list, final Table table) {
         super(list, table);
     }
-    
-    /**
-     * Contains all columns that represent a time value
-     * which may need to be formatted accordingly.
-     */
-    private List<TableColumn> timeColumnList = new ArrayList<TableColumn>();
-    
-    /**
-     * Contains all columns that represent length values (MIs)
-     * which may need to be formatted accordingly.
-     */
-    private List<TableColumn> lengthColumnList = new ArrayList<TableColumn>();
-    
-    /**
-     * Contains all columns that represent ID values
-     * which may need to be formatted accordingly.
-     */
-    private List<TableColumn> idColumnList = new ArrayList<TableColumn>();
-    
-    /**
-     * Contains all columns that represent PE counts
-     * which may need to be formatted accordingly.
-     */
-    private List<TableColumn> peColumnList = new ArrayList<TableColumn>();
 
     @Override
     protected void createTableColumns() {
@@ -103,104 +79,45 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
         // Set up all table fields
         
         // Cloudlet
-        final var cloudletCol = getTable().addColumn("Cloudlet", ID,getIDFormat());
-        idColumnList.add(cloudletCol);
-        addColDataFunction(cloudletCol, Identifiable::getId);
+        addColDataFunction(getTable().addColumn("Cloudlet", ID), Identifiable::getId);
         
         // Status
-        final var statusCol = getTable().addColumn("Status "); // 1 extra space to ensure proper formatting
-        addColDataFunction(statusCol , cloudlet -> cloudlet.getStatus().name());
+        // 1 extra space to ensure proper formatting
+        addColDataFunction(getTable().addColumn("Status ") , cloudlet -> cloudlet.getStatus().name());
         
-        // DC
-        final var dcCol = getTable().addColumn("DC", ID,getIDFormat());
-        idColumnList.add(dcCol);
-        addColDataFunction(dcCol, cloudlet -> cloudlet.getVm().getHost().getDatacenter().getId());
+        // DC (Datacenter)
+        addColDataFunction(getTable().addColumn("DC", ID,DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getHost().getDatacenter().getId());
         
         // Host
-        final var hostCol = getTable().addColumn("Host", ID,getIDFormat());
-        idColumnList.add(hostCol);
-        addColDataFunction(hostCol, cloudlet -> cloudlet.getVm().getHost().getId());
+        addColDataFunction(getTable().addColumn("Host", ID,DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getHost().getId());
         
         // Host PEs
-        final var hostPEsCol = getTable().addColumn("Host PEs ", CPU_CORES,getPEFormat());
-        peColumnList.add(hostPEsCol);
-        addColDataFunction(hostPEsCol, cloudlet -> cloudlet.getVm().getHost().getWorkingPesNumber());
+        addColDataFunction(getTable().addColumn("Host PEs ", CPU_CORES,DEFAULT_PE_FORMAT), cloudlet -> cloudlet.getVm().getHost().getWorkingPesNumber());
         
         // VM
-        final var vmCol = getTable().addColumn("VM", ID,getIDFormat());
-        idColumnList.add(vmCol);
-        addColDataFunction(vmCol, cloudlet -> cloudlet.getVm().getId());
+        addColDataFunction(getTable().addColumn("VM", ID,DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getId());
         
         // VM PEs
-        final var vmPEsCol = getTable().addColumn("VM PEs   ", CPU_CORES,getPEFormat()); // 3 extra spaces to ensure proper formatting
-        peColumnList.add(vmPEsCol);
-        addColDataFunction(vmPEsCol, cloudlet -> cloudlet.getVm().getNumberOfPes());
+        // 3 extra spaces to ensure proper formatting
+        addColDataFunction(getTable().addColumn("VM PEs   ", CPU_CORES,DEFAULT_PE_FORMAT), cloudlet -> cloudlet.getVm().getNumberOfPes());
         
         // CloudletLen
-        final var cloudletLenCol = getTable().addColumn("CloudletLen", "MI",getLengthFormat());
-        lengthColumnList.add(cloudletLenCol);
-        addColDataFunction(cloudletLenCol, Cloudlet::getLength);
+        addColDataFunction(getTable().addColumn("CloudletLen", "MI",DEFAULT_LENGTH_FORMAT), Cloudlet::getLength);
         
         // FinishedLen
-        final var finishedLenCol = getTable().addColumn("FinishedLen", "MI",getLengthFormat());
-        lengthColumnList.add(finishedLenCol);
-        addColDataFunction(finishedLenCol, Cloudlet::getFinishedLengthSoFar);
+        addColDataFunction(getTable().addColumn("FinishedLen", "MI",DEFAULT_LENGTH_FORMAT), Cloudlet::getFinishedLengthSoFar);
         
         // CloudletPEs
-        final var cloudletPEsCol = getTable().addColumn("CloudletPEs", CPU_CORES,getPEFormat());
-        lengthColumnList.add(cloudletPEsCol);
-        addColDataFunction(cloudletPEsCol, Cloudlet::getNumberOfPes);
+        addColDataFunction(getTable().addColumn("CloudletPEs", CPU_CORES,DEFAULT_PE_FORMAT), Cloudlet::getNumberOfPes);
 
         // StartTime
-        final var startTimeCol = getTable().addColumn("StartTime", SECONDS,getTimeFormat());
-        timeColumnList.add(startTimeCol);
-        addColDataFunction(startTimeCol, Cloudlet::getExecStartTime);
+        addColDataFunction(getTable().addColumn("StartTime", SECONDS,DEFAULT_TIME_FORMAT), Cloudlet::getExecStartTime);
 
         // FinishTime
-        final var finishTimeCol = getTable().addColumn("FinishTime", SECONDS,getTimeFormat());
-        timeColumnList.add(finishTimeCol);
-        addColDataFunction(finishTimeCol, cl -> cl.getFinishTime());
+        addColDataFunction(getTable().addColumn("FinishTime", SECONDS,DEFAULT_TIME_FORMAT), cl -> cl.getFinishTime());
 
         // ExecTime
-        final var execTimeCol = getTable().addColumn("ExecTime", SECONDS,getTimeFormat());
-        timeColumnList.add(execTimeCol);
-        addColDataFunction(execTimeCol, cl ->  cl.getActualCpuTime());
-    }
-    
-    public CloudletsTableBuilder setTimeFormat(String format) {
-    	this.timeFormat = format;
-    	return this;
-    }
-    
-    public CloudletsTableBuilder setLengthFormat(String format) {
-    	this.lengthFormat = format;
-    	return this;
-    }
-    
-    public CloudletsTableBuilder setPEFormat(String format) {
-    	this.peFormat = format;
-    	return this;
-    }
-    
-    public CloudletsTableBuilder setIDFormat(String format) {
-    	this.idFormat = format;
-    	return this;
-    }
-    
-    public String getTimeFormat() {
-    	return this.timeFormat;
-    }
-    
-    public String getLengthFormat() {
-    	return this.lengthFormat;
-    }
-    
-    public String getPEFormat() {
-    	return this.peFormat;
-    }
-    
-    public String getIDFormat() {
-    	return this.idFormat;
+        addColDataFunction(getTable().addColumn("ExecTime", SECONDS,DEFAULT_TIME_FORMAT), cl ->  cl.getActualCpuTime());
     }
 
 }

--- a/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
@@ -124,7 +124,7 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
         // Set up all table fields
         
         // Cloudlet
-        final var cloudletCol = getTable().addColumn("Cloudlet", ID).setFormat(getIDFormat());
+        final var cloudletCol = getTable().addColumn("Cloudlet", ID,getIDFormat());
         idColumnList.add(cloudletCol);
         addColDataFunction(cloudletCol, Identifiable::getId);
         
@@ -133,57 +133,57 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
         addColDataFunction(statusCol , cloudlet -> cloudlet.getStatus().name());
         
         // DC
-        final var dcCol = getTable().addColumn("DC", ID).setFormat(getIDFormat());
+        final var dcCol = getTable().addColumn("DC", ID,getIDFormat());
         idColumnList.add(dcCol);
         addColDataFunction(dcCol, cloudlet -> cloudlet.getVm().getHost().getDatacenter().getId());
         
         // Host
-        final var hostCol = getTable().addColumn("Host", ID).setFormat(getIDFormat());
+        final var hostCol = getTable().addColumn("Host", ID,getIDFormat());
         idColumnList.add(hostCol);
         addColDataFunction(hostCol, cloudlet -> cloudlet.getVm().getHost().getId());
         
         // Host PEs
-        final var hostPEsCol = getTable().addColumn("Host PEs ", CPU_CORES).setFormat(getPEFormat());
+        final var hostPEsCol = getTable().addColumn("Host PEs ", CPU_CORES,getPEFormat());
         peColumnList.add(hostPEsCol);
         addColDataFunction(hostPEsCol, cloudlet -> cloudlet.getVm().getHost().getWorkingPesNumber());
         
         // VM
-        final var vmCol = getTable().addColumn("VM", ID).setFormat(getIDFormat());
+        final var vmCol = getTable().addColumn("VM", ID,getIDFormat());
         idColumnList.add(vmCol);
         addColDataFunction(vmCol, cloudlet -> cloudlet.getVm().getId());
         
         // VM PEs
-        final var vmPEsCol = getTable().addColumn("VM PEs   ", CPU_CORES).setFormat(getPEFormat()); // 3 extra spaces to ensure proper formatting
+        final var vmPEsCol = getTable().addColumn("VM PEs   ", CPU_CORES,getPEFormat()); // 3 extra spaces to ensure proper formatting
         peColumnList.add(vmPEsCol);
         addColDataFunction(vmPEsCol, cloudlet -> cloudlet.getVm().getNumberOfPes());
         
         // CloudletLen
-        final var cloudletLenCol = getTable().addColumn("CloudletLen", "MI").setFormat(getLengthFormat());
+        final var cloudletLenCol = getTable().addColumn("CloudletLen", "MI",getLengthFormat());
         lengthColumnList.add(cloudletLenCol);
         addColDataFunction(cloudletLenCol, Cloudlet::getLength);
         
         // FinishedLen
-        final var finishedLenCol = getTable().addColumn("FinishedLen", "MI").setFormat(getLengthFormat());
+        final var finishedLenCol = getTable().addColumn("FinishedLen", "MI",getLengthFormat());
         lengthColumnList.add(finishedLenCol);
         addColDataFunction(finishedLenCol, Cloudlet::getFinishedLengthSoFar);
         
         // CloudletPEs
-        final var cloudletPEsCol = getTable().addColumn("CloudletPEs", CPU_CORES).setFormat(getPEFormat());
+        final var cloudletPEsCol = getTable().addColumn("CloudletPEs", CPU_CORES,getPEFormat());
         lengthColumnList.add(cloudletPEsCol);
         addColDataFunction(cloudletPEsCol, Cloudlet::getNumberOfPes);
 
         // StartTime
-        final var startTimeCol = getTable().addColumn("StartTime", SECONDS).setFormat(getTimeFormat());
+        final var startTimeCol = getTable().addColumn("StartTime", SECONDS,getTimeFormat());
         timeColumnList.add(startTimeCol);
         addColDataFunction(startTimeCol, Cloudlet::getExecStartTime);
 
         // FinishTime
-        final var finishTimeCol = getTable().addColumn("FinishTime", SECONDS).setFormat(getTimeFormat());
+        final var finishTimeCol = getTable().addColumn("FinishTime", SECONDS,getTimeFormat());
         timeColumnList.add(finishTimeCol);
         addColDataFunction(finishTimeCol, cl -> cl.getFinishTime());
 
         // ExecTime
-        final var execTimeCol = getTable().addColumn("ExecTime", SECONDS).setFormat(getTimeFormat());
+        final var execTimeCol = getTable().addColumn("ExecTime", SECONDS,getTimeFormat());
         timeColumnList.add(execTimeCol);
         addColDataFunction(execTimeCol, cl ->  cl.getActualCpuTime());
     }

--- a/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
@@ -97,6 +97,7 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
         addColDataFunction(addColumn("ExecTime", SECONDS, DEFAULT_TIME_FORMAT), Cloudlet::getActualCpuTime);
     }
 
+    //TODO: those methods need to be moved to TableBuilderAbstract (there are similar methods there)
     private TableColumn addColumn(final String title, final String subtitle) {
         return addColumn(title, subtitle, "");
     }

--- a/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
@@ -45,11 +45,11 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
     private static final String SECONDS = "Seconds";
     private static final String CPU_CORES = "CPU cores";
     private static final String ID = "ID";
-    
-    private String timeFormat;
-    private String lengthFormat;
-    private String idFormat;
-    private String peFormat;
+	
+	private String timeFormat = "%.1f";
+	private String lengthFormat = "%d";
+	private String idFormat = "%d";
+	private String peFormat = "%d";
 
     /**
      * Instantiates a builder to print the list of Cloudlets using the a
@@ -77,49 +77,28 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
      * Contains all columns that represent a time value
      * which may need to be formatted accordingly.
      */
-    private List<TableColumn> timeColumnList;
+    private List<TableColumn> timeColumnList = new ArrayList<TableColumn>();
     
     /**
      * Contains all columns that represent length values (MIs)
      * which may need to be formatted accordingly.
      */
-    private List<TableColumn> lengthColumnList;
+    private List<TableColumn> lengthColumnList = new ArrayList<TableColumn>();
     
     /**
      * Contains all columns that represent ID values
      * which may need to be formatted accordingly.
      */
-    private List<TableColumn> idColumnList;
+    private List<TableColumn> idColumnList = new ArrayList<TableColumn>();
     
     /**
      * Contains all columns that represent PE counts
      * which may need to be formatted accordingly.
      */
-    private List<TableColumn> peColumnList;
-    
-    /**
-     *  Initialize lists and default formats.
-     *  This has to be done here because the createTableColumns() function gets executed by the superclass before these class
-     *  variables would normally get initialized if they were assigned the normal way (which is after the constructor of the superclass has finished).
-     *  This function ensures that they are already present for createTableColumns().
-     */
-    private void initializeFormattingSettings() {
-
-    	timeColumnList = new ArrayList<TableColumn>();
-    	lengthColumnList = new ArrayList<TableColumn>();
-    	idColumnList = new ArrayList<TableColumn>();
-    	peColumnList = new ArrayList<TableColumn>();
-    	
-    	timeFormat = "%.1f";
-        lengthFormat = "%d";
-        idFormat = "%d";
-        peFormat = "%d";
-    }
+    private List<TableColumn> peColumnList = new ArrayList<TableColumn>();
 
     @Override
     protected void createTableColumns() {
-    	
-    	initializeFormattingSettings();
         
         // Set up all table fields
         
@@ -187,9 +166,6 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
         timeColumnList.add(execTimeCol);
         addColDataFunction(execTimeCol, cl ->  cl.getActualCpuTime());
     }
-    
-    // TODO: Just setting the variables is not enough.
-    // The setters need to iterate through their respective lists to actually adjust the formatting on the individual columns.
     
     public CloudletsTableBuilder setTimeFormat(String format) {
     	this.timeFormat = format;

--- a/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
@@ -75,26 +75,26 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
 
     @Override
     protected void createTableColumns() {
-        addColDataFunction(addColumn("Cloudlet", ID), Identifiable::getId);
+        mapColDataFunction(addColumn("Cloudlet", ID), Identifiable::getId);
 
         // 1 extra space to ensure proper formatting
-        addColDataFunction(getTable().addColumn(" Status") , cloudlet -> cloudlet.getStatus().name());
+        mapColDataFunction(getTable().addColumn(" Status") , cloudlet -> cloudlet.getStatus().name());
 
-        addColDataFunction(addColumn("DC", ID, DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getHost().getDatacenter().getId());
+        mapColDataFunction(addColumn("DC", ID, DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getHost().getDatacenter().getId());
 
-        addColDataFunction(addColumn("Host", ID, DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getHost().getId());
-        addColDataFunction(addColumn("Host PEs ", CPU_CORES, DEFAULT_PE_FORMAT), cloudlet -> cloudlet.getVm().getHost().getWorkingPesNumber());
+        mapColDataFunction(addColumn("Host", ID, DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getHost().getId());
+        mapColDataFunction(addColumn("Host PEs ", CPU_CORES, DEFAULT_PE_FORMAT), cloudlet -> cloudlet.getVm().getHost().getWorkingPesNumber());
 
-        addColDataFunction(addColumn("VM", ID, DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getId());
+        mapColDataFunction(addColumn("VM", ID, DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getId());
 
         // 3 extra spaces to ensure proper formatting
-        addColDataFunction(addColumn("   VM PEs", CPU_CORES, DEFAULT_PE_FORMAT), cloudlet -> cloudlet.getVm().getNumberOfPes());
-        addColDataFunction(addColumn("CloudletLen", MI, DEFAULT_LENGTH_FORMAT), Cloudlet::getLength);
-        addColDataFunction(addColumn("FinishedLen", MI, DEFAULT_LENGTH_FORMAT), Cloudlet::getFinishedLengthSoFar);
-        addColDataFunction(addColumn("CloudletPEs", CPU_CORES, DEFAULT_PE_FORMAT), Cloudlet::getNumberOfPes);
-        addColDataFunction(addColumn("StartTime", SECONDS, DEFAULT_TIME_FORMAT), Cloudlet::getExecStartTime);
-        addColDataFunction(addColumn("FinishTime", SECONDS, DEFAULT_TIME_FORMAT), Cloudlet::getFinishTime);
-        addColDataFunction(addColumn("ExecTime", SECONDS, DEFAULT_TIME_FORMAT), Cloudlet::getActualCpuTime);
+        mapColDataFunction(addColumn("   VM PEs", CPU_CORES, DEFAULT_PE_FORMAT), cloudlet -> cloudlet.getVm().getNumberOfPes());
+        mapColDataFunction(addColumn("CloudletLen", MI, DEFAULT_LENGTH_FORMAT), Cloudlet::getLength);
+        mapColDataFunction(addColumn("FinishedLen", MI, DEFAULT_LENGTH_FORMAT), Cloudlet::getFinishedLengthSoFar);
+        mapColDataFunction(addColumn("CloudletPEs", CPU_CORES, DEFAULT_PE_FORMAT), Cloudlet::getNumberOfPes);
+        mapColDataFunction(addColumn("StartTime", SECONDS, DEFAULT_TIME_FORMAT), Cloudlet::getExecStartTime);
+        mapColDataFunction(addColumn("FinishTime", SECONDS, DEFAULT_TIME_FORMAT), Cloudlet::getFinishTime);
+        mapColDataFunction(addColumn("ExecTime", SECONDS, DEFAULT_TIME_FORMAT), Cloudlet::getActualCpuTime);
     }
 
 }

--- a/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
@@ -31,7 +31,7 @@ import java.util.List;
 /**
  * Builds a table for printing simulation results from a list of Cloudlets.
  * It defines a set of default columns but new ones can be added
- * dynamically using the {@code addColumn()} methods.
+ * dynamically using the {@code newColumn()} methods.
  *
  * <p>The basic usage of the class is by calling its constructor,
  * giving a list of Cloudlets to be printed, and then
@@ -75,34 +75,26 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
 
     @Override
     protected void createTableColumns() {
-        addColDataFunction(addColumn("Cloudlet", ID), Identifiable::getId);
+        addColDataFunction(newColumn("Cloudlet", ID), Identifiable::getId);
 
         // 1 extra space to ensure proper formatting
         addColDataFunction(getTable().addColumn(" Status") , cloudlet -> cloudlet.getStatus().name());
 
-        addColDataFunction(addColumn("DC", ID, DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getHost().getDatacenter().getId());
+        addColDataFunction(newColumn("DC", ID, DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getHost().getDatacenter().getId());
 
-        addColDataFunction(addColumn("Host", ID, DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getHost().getId());
-        addColDataFunction(addColumn("Host PEs ", CPU_CORES, DEFAULT_PE_FORMAT), cloudlet -> cloudlet.getVm().getHost().getWorkingPesNumber());
+        addColDataFunction(newColumn("Host", ID, DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getHost().getId());
+        addColDataFunction(newColumn("Host PEs ", CPU_CORES, DEFAULT_PE_FORMAT), cloudlet -> cloudlet.getVm().getHost().getWorkingPesNumber());
 
-        addColDataFunction(addColumn("VM", ID, DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getId());
+        addColDataFunction(newColumn("VM", ID, DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getId());
 
         // 3 extra spaces to ensure proper formatting
-        addColDataFunction(addColumn("   VM PEs", CPU_CORES, DEFAULT_PE_FORMAT), cloudlet -> cloudlet.getVm().getNumberOfPes());
-        addColDataFunction(addColumn("CloudletLen", MI, DEFAULT_LENGTH_FORMAT), Cloudlet::getLength);
-        addColDataFunction(addColumn("FinishedLen", MI, DEFAULT_LENGTH_FORMAT), Cloudlet::getFinishedLengthSoFar);
-        addColDataFunction(addColumn("CloudletPEs", CPU_CORES, DEFAULT_PE_FORMAT), Cloudlet::getNumberOfPes);
-        addColDataFunction(addColumn("StartTime", SECONDS, DEFAULT_TIME_FORMAT), Cloudlet::getExecStartTime);
-        addColDataFunction(addColumn("FinishTime", SECONDS, DEFAULT_TIME_FORMAT), Cloudlet::getFinishTime);
-        addColDataFunction(addColumn("ExecTime", SECONDS, DEFAULT_TIME_FORMAT), Cloudlet::getActualCpuTime);
+        addColDataFunction(newColumn("   VM PEs", CPU_CORES, DEFAULT_PE_FORMAT), cloudlet -> cloudlet.getVm().getNumberOfPes());
+        addColDataFunction(newColumn("CloudletLen", MI, DEFAULT_LENGTH_FORMAT), Cloudlet::getLength);
+        addColDataFunction(newColumn("FinishedLen", MI, DEFAULT_LENGTH_FORMAT), Cloudlet::getFinishedLengthSoFar);
+        addColDataFunction(newColumn("CloudletPEs", CPU_CORES, DEFAULT_PE_FORMAT), Cloudlet::getNumberOfPes);
+        addColDataFunction(newColumn("StartTime", SECONDS, DEFAULT_TIME_FORMAT), Cloudlet::getExecStartTime);
+        addColDataFunction(newColumn("FinishTime", SECONDS, DEFAULT_TIME_FORMAT), Cloudlet::getFinishTime);
+        addColDataFunction(newColumn("ExecTime", SECONDS, DEFAULT_TIME_FORMAT), Cloudlet::getActualCpuTime);
     }
 
-    //TODO: those methods need to be moved to TableBuilderAbstract (there are similar methods there)
-    private TableColumn addColumn(final String title, final String subtitle) {
-        return addColumn(title, subtitle, "");
-    }
-
-    private TableColumn addColumn(final String title, final String subtitle, final String format) {
-        return getTable().addColumn(title, subtitle, format);
-    }
 }

--- a/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
@@ -93,8 +93,8 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
         addColDataFunction(getTable().addColumn("FinishedLen", MI, DEFAULT_LENGTH_FORMAT), Cloudlet::getFinishedLengthSoFar);
         addColDataFunction(getTable().addColumn("CloudletPEs", CPU_CORES, DEFAULT_PE_FORMAT), Cloudlet::getNumberOfPes);
         addColDataFunction(getTable().addColumn("StartTime", SECONDS, DEFAULT_TIME_FORMAT), Cloudlet::getExecStartTime);
-        addColDataFunction(getTable().addColumn("FinishTime", SECONDS, DEFAULT_TIME_FORMAT), cl -> cl.getFinishTime());
-        addColDataFunction(getTable().addColumn("ExecTime", SECONDS, DEFAULT_TIME_FORMAT), cl ->  cl.getActualCpuTime());
+        addColDataFunction(getTable().addColumn("FinishTime", SECONDS, DEFAULT_TIME_FORMAT), Cloudlet::getFinishTime);
+        addColDataFunction(getTable().addColumn("ExecTime", SECONDS, DEFAULT_TIME_FORMAT), Cloudlet::getActualCpuTime);
     }
 
 }

--- a/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
@@ -45,7 +45,7 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
     private static final String CPU_CORES = "CPU cores";
     private static final String ID = "ID";
     private static final String MI = "MI";
-	
+
 	private static final String DEFAULT_TIME_FORMAT = "%.1f";
 	private static final String DEFAULT_LENGTH_FORMAT = "%d";
 	private static final String DEFAULT_ID_FORMAT = "%d";
@@ -80,21 +80,21 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
         // 1 extra space to ensure proper formatting
         addColDataFunction(getTable().addColumn(" Status") , cloudlet -> cloudlet.getStatus().name());
 
-        addColDataFunction(getTable().addColumn("DC", ID,DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getHost().getDatacenter().getId());
+        addColDataFunction(getTable().addColumn("DC", ID, DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getHost().getDatacenter().getId());
 
-        addColDataFunction(getTable().addColumn("Host", ID,DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getHost().getId());
-        addColDataFunction(getTable().addColumn("Host PEs ", CPU_CORES,DEFAULT_PE_FORMAT), cloudlet -> cloudlet.getVm().getHost().getWorkingPesNumber());
+        addColDataFunction(getTable().addColumn("Host", ID, DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getHost().getId());
+        addColDataFunction(getTable().addColumn("Host PEs ", CPU_CORES, DEFAULT_PE_FORMAT), cloudlet -> cloudlet.getVm().getHost().getWorkingPesNumber());
 
-        addColDataFunction(getTable().addColumn("VM", ID,DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getId());
+        addColDataFunction(getTable().addColumn("VM", ID, DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getId());
 
         // 3 extra spaces to ensure proper formatting
-        addColDataFunction(getTable().addColumn("   VM PEs", CPU_CORES,DEFAULT_PE_FORMAT), cloudlet -> cloudlet.getVm().getNumberOfPes());
-        addColDataFunction(getTable().addColumn("CloudletLen", MI,DEFAULT_LENGTH_FORMAT), Cloudlet::getLength);
-        addColDataFunction(getTable().addColumn("FinishedLen", MI,DEFAULT_LENGTH_FORMAT), Cloudlet::getFinishedLengthSoFar);
-        addColDataFunction(getTable().addColumn("CloudletPEs", CPU_CORES,DEFAULT_PE_FORMAT), Cloudlet::getNumberOfPes);
-        addColDataFunction(getTable().addColumn("StartTime", SECONDS,DEFAULT_TIME_FORMAT), Cloudlet::getExecStartTime);
-        addColDataFunction(getTable().addColumn("FinishTime", SECONDS,DEFAULT_TIME_FORMAT), cl -> cl.getFinishTime());
-        addColDataFunction(getTable().addColumn("ExecTime", SECONDS,DEFAULT_TIME_FORMAT), cl ->  cl.getActualCpuTime());
+        addColDataFunction(getTable().addColumn("   VM PEs", CPU_CORES, DEFAULT_PE_FORMAT), cloudlet -> cloudlet.getVm().getNumberOfPes());
+        addColDataFunction(getTable().addColumn("CloudletLen", MI, DEFAULT_LENGTH_FORMAT), Cloudlet::getLength);
+        addColDataFunction(getTable().addColumn("FinishedLen", MI, DEFAULT_LENGTH_FORMAT), Cloudlet::getFinishedLengthSoFar);
+        addColDataFunction(getTable().addColumn("CloudletPEs", CPU_CORES, DEFAULT_PE_FORMAT), Cloudlet::getNumberOfPes);
+        addColDataFunction(getTable().addColumn("StartTime", SECONDS, DEFAULT_TIME_FORMAT), Cloudlet::getExecStartTime);
+        addColDataFunction(getTable().addColumn("FinishTime", SECONDS, DEFAULT_TIME_FORMAT), cl -> cl.getFinishTime());
+        addColDataFunction(getTable().addColumn("ExecTime", SECONDS, DEFAULT_TIME_FORMAT), cl ->  cl.getActualCpuTime());
     }
 
 }

--- a/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
@@ -75,26 +75,33 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
 
     @Override
     protected void createTableColumns() {
-        addColDataFunction(getTable().addColumn("Cloudlet", ID), Identifiable::getId);
+        addColDataFunction(addColumn("Cloudlet", ID), Identifiable::getId);
 
         // 1 extra space to ensure proper formatting
         addColDataFunction(getTable().addColumn(" Status") , cloudlet -> cloudlet.getStatus().name());
 
-        addColDataFunction(getTable().addColumn("DC", ID, DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getHost().getDatacenter().getId());
+        addColDataFunction(addColumn("DC", ID, DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getHost().getDatacenter().getId());
 
-        addColDataFunction(getTable().addColumn("Host", ID, DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getHost().getId());
-        addColDataFunction(getTable().addColumn("Host PEs ", CPU_CORES, DEFAULT_PE_FORMAT), cloudlet -> cloudlet.getVm().getHost().getWorkingPesNumber());
+        addColDataFunction(addColumn("Host", ID, DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getHost().getId());
+        addColDataFunction(addColumn("Host PEs ", CPU_CORES, DEFAULT_PE_FORMAT), cloudlet -> cloudlet.getVm().getHost().getWorkingPesNumber());
 
-        addColDataFunction(getTable().addColumn("VM", ID, DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getId());
+        addColDataFunction(addColumn("VM", ID, DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getId());
 
         // 3 extra spaces to ensure proper formatting
-        addColDataFunction(getTable().addColumn("   VM PEs", CPU_CORES, DEFAULT_PE_FORMAT), cloudlet -> cloudlet.getVm().getNumberOfPes());
-        addColDataFunction(getTable().addColumn("CloudletLen", MI, DEFAULT_LENGTH_FORMAT), Cloudlet::getLength);
-        addColDataFunction(getTable().addColumn("FinishedLen", MI, DEFAULT_LENGTH_FORMAT), Cloudlet::getFinishedLengthSoFar);
-        addColDataFunction(getTable().addColumn("CloudletPEs", CPU_CORES, DEFAULT_PE_FORMAT), Cloudlet::getNumberOfPes);
-        addColDataFunction(getTable().addColumn("StartTime", SECONDS, DEFAULT_TIME_FORMAT), Cloudlet::getExecStartTime);
-        addColDataFunction(getTable().addColumn("FinishTime", SECONDS, DEFAULT_TIME_FORMAT), Cloudlet::getFinishTime);
-        addColDataFunction(getTable().addColumn("ExecTime", SECONDS, DEFAULT_TIME_FORMAT), Cloudlet::getActualCpuTime);
+        addColDataFunction(addColumn("   VM PEs", CPU_CORES, DEFAULT_PE_FORMAT), cloudlet -> cloudlet.getVm().getNumberOfPes());
+        addColDataFunction(addColumn("CloudletLen", MI, DEFAULT_LENGTH_FORMAT), Cloudlet::getLength);
+        addColDataFunction(addColumn("FinishedLen", MI, DEFAULT_LENGTH_FORMAT), Cloudlet::getFinishedLengthSoFar);
+        addColDataFunction(addColumn("CloudletPEs", CPU_CORES, DEFAULT_PE_FORMAT), Cloudlet::getNumberOfPes);
+        addColDataFunction(addColumn("StartTime", SECONDS, DEFAULT_TIME_FORMAT), Cloudlet::getExecStartTime);
+        addColDataFunction(addColumn("FinishTime", SECONDS, DEFAULT_TIME_FORMAT), Cloudlet::getFinishTime);
+        addColDataFunction(addColumn("ExecTime", SECONDS, DEFAULT_TIME_FORMAT), Cloudlet::getActualCpuTime);
     }
 
+    private TableColumn addColumn(final String title, final String subtitle) {
+        return getTable().addColumn(title, subtitle, "");
+    }
+
+    private TableColumn addColumn(final String title, final String subtitle, final String format) {
+        return getTable().addColumn(title, subtitle, format);
+    }
 }

--- a/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
@@ -83,7 +83,7 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
         
         // Status
         // 1 extra space to ensure proper formatting
-        addColDataFunction(getTable().addColumn("Status ") , cloudlet -> cloudlet.getStatus().name());
+        addColDataFunction(getTable().addColumn(" Status") , cloudlet -> cloudlet.getStatus().name());
         
         // DC (Datacenter)
         addColDataFunction(getTable().addColumn("DC", ID,DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getHost().getDatacenter().getId());
@@ -99,7 +99,7 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
         
         // VM PEs
         // 3 extra spaces to ensure proper formatting
-        addColDataFunction(getTable().addColumn("VM PEs   ", CPU_CORES,DEFAULT_PE_FORMAT), cloudlet -> cloudlet.getVm().getNumberOfPes());
+        addColDataFunction(getTable().addColumn("   VM PEs", CPU_CORES,DEFAULT_PE_FORMAT), cloudlet -> cloudlet.getVm().getNumberOfPes());
         
         // CloudletLen
         addColDataFunction(getTable().addColumn("CloudletLen", "MI",DEFAULT_LENGTH_FORMAT), Cloudlet::getLength);

--- a/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
@@ -114,7 +114,7 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
     	
     	timeFormat = "%.0f";
         lengthFormat = "%d";
-        idFormat = "%02d";
+        idFormat = "%d";
         peFormat = "%d";
         
         // Set up all table fields
@@ -164,7 +164,7 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
         addColDataFunction(finishedLenCol, Cloudlet::getFinishedLengthSoFar);
         
         // CloudletPEs
-        final var cloudletPEsCol = getTable().addColumn("CloudletPEs", CPU_CORES).setFormat(getIDFormat());
+        final var cloudletPEsCol = getTable().addColumn("CloudletPEs", CPU_CORES).setFormat(getPEFormat());
         lengthColumnList.add(cloudletPEsCol);
         addColDataFunction(cloudletPEsCol, Cloudlet::getNumberOfPes);
 

--- a/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
@@ -76,8 +76,6 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
     @Override
     protected void createTableColumns() {
         
-        // Set up all table fields
-        
         // Cloudlet
         addColDataFunction(getTable().addColumn("Cloudlet", ID), Identifiable::getId);
         

--- a/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
@@ -75,46 +75,25 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
 
     @Override
     protected void createTableColumns() {
-        
-        // Cloudlet
         addColDataFunction(getTable().addColumn("Cloudlet", ID), Identifiable::getId);
-        
-        // Status
+
         // 1 extra space to ensure proper formatting
         addColDataFunction(getTable().addColumn(" Status") , cloudlet -> cloudlet.getStatus().name());
-        
-        // DC (Datacenter)
+
         addColDataFunction(getTable().addColumn("DC", ID,DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getHost().getDatacenter().getId());
-        
-        // Host
+
         addColDataFunction(getTable().addColumn("Host", ID,DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getHost().getId());
-        
-        // Host PEs
         addColDataFunction(getTable().addColumn("Host PEs ", CPU_CORES,DEFAULT_PE_FORMAT), cloudlet -> cloudlet.getVm().getHost().getWorkingPesNumber());
-        
-        // VM
+
         addColDataFunction(getTable().addColumn("VM", ID,DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getId());
-        
-        // VM PEs
+
         // 3 extra spaces to ensure proper formatting
         addColDataFunction(getTable().addColumn("   VM PEs", CPU_CORES,DEFAULT_PE_FORMAT), cloudlet -> cloudlet.getVm().getNumberOfPes());
-        
-        // CloudletLen
         addColDataFunction(getTable().addColumn("CloudletLen", MI,DEFAULT_LENGTH_FORMAT), Cloudlet::getLength);
-        
-        // FinishedLen
         addColDataFunction(getTable().addColumn("FinishedLen", MI,DEFAULT_LENGTH_FORMAT), Cloudlet::getFinishedLengthSoFar);
-        
-        // CloudletPEs
         addColDataFunction(getTable().addColumn("CloudletPEs", CPU_CORES,DEFAULT_PE_FORMAT), Cloudlet::getNumberOfPes);
-
-        // StartTime
         addColDataFunction(getTable().addColumn("StartTime", SECONDS,DEFAULT_TIME_FORMAT), Cloudlet::getExecStartTime);
-
-        // FinishTime
         addColDataFunction(getTable().addColumn("FinishTime", SECONDS,DEFAULT_TIME_FORMAT), cl -> cl.getFinishTime());
-
-        // ExecTime
         addColDataFunction(getTable().addColumn("ExecTime", SECONDS,DEFAULT_TIME_FORMAT), cl ->  cl.getActualCpuTime());
     }
 

--- a/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
@@ -184,20 +184,24 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
         addColDataFunction(execTimeCol, cl -> roundTime(cl, cl.getActualCpuTime()));
     }
     
-    public void setTimeFormat(String format) {
+    public CloudletsTableBuilder setTimeFormat(String format) {
     	this.timeFormat = format;
+    	return this;
     }
     
-    public void setLengthFormat(String format) {
+    public CloudletsTableBuilder setLengthFormat(String format) {
     	this.lengthFormat = format;
+    	return this;
     }
     
-    public void setPEFormat(String format) {
+    public CloudletsTableBuilder setPEFormat(String format) {
     	this.peFormat = format;
+    	return this;
     }
     
-    public void setIDFormat(String format) {
+    public CloudletsTableBuilder setIDFormat(String format) {
     	this.idFormat = format;
+    	return this;
     }
     
     public String getTimeFormat() {

--- a/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
@@ -112,7 +112,7 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
     	idColumnList = new ArrayList<TableColumn>();
     	peColumnList = new ArrayList<TableColumn>();
     	
-    	timeFormat = "%.0f";
+    	timeFormat = "%.1f";
         lengthFormat = "%d";
         idFormat = "%d";
         peFormat = "%d";

--- a/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
@@ -31,7 +31,7 @@ import java.util.List;
 /**
  * Builds a table for printing simulation results from a list of Cloudlets.
  * It defines a set of default columns but new ones can be added
- * dynamically using the {@code newColumn()} methods.
+ * dynamically using the {@code addColumn()} methods.
  *
  * <p>The basic usage of the class is by calling its constructor,
  * giving a list of Cloudlets to be printed, and then
@@ -75,26 +75,26 @@ public class CloudletsTableBuilder extends TableBuilderAbstract<Cloudlet> {
 
     @Override
     protected void createTableColumns() {
-        addColDataFunction(newColumn("Cloudlet", ID), Identifiable::getId);
+        addColDataFunction(addColumn("Cloudlet", ID), Identifiable::getId);
 
         // 1 extra space to ensure proper formatting
         addColDataFunction(getTable().addColumn(" Status") , cloudlet -> cloudlet.getStatus().name());
 
-        addColDataFunction(newColumn("DC", ID, DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getHost().getDatacenter().getId());
+        addColDataFunction(addColumn("DC", ID, DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getHost().getDatacenter().getId());
 
-        addColDataFunction(newColumn("Host", ID, DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getHost().getId());
-        addColDataFunction(newColumn("Host PEs ", CPU_CORES, DEFAULT_PE_FORMAT), cloudlet -> cloudlet.getVm().getHost().getWorkingPesNumber());
+        addColDataFunction(addColumn("Host", ID, DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getHost().getId());
+        addColDataFunction(addColumn("Host PEs ", CPU_CORES, DEFAULT_PE_FORMAT), cloudlet -> cloudlet.getVm().getHost().getWorkingPesNumber());
 
-        addColDataFunction(newColumn("VM", ID, DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getId());
+        addColDataFunction(addColumn("VM", ID, DEFAULT_ID_FORMAT), cloudlet -> cloudlet.getVm().getId());
 
         // 3 extra spaces to ensure proper formatting
-        addColDataFunction(newColumn("   VM PEs", CPU_CORES, DEFAULT_PE_FORMAT), cloudlet -> cloudlet.getVm().getNumberOfPes());
-        addColDataFunction(newColumn("CloudletLen", MI, DEFAULT_LENGTH_FORMAT), Cloudlet::getLength);
-        addColDataFunction(newColumn("FinishedLen", MI, DEFAULT_LENGTH_FORMAT), Cloudlet::getFinishedLengthSoFar);
-        addColDataFunction(newColumn("CloudletPEs", CPU_CORES, DEFAULT_PE_FORMAT), Cloudlet::getNumberOfPes);
-        addColDataFunction(newColumn("StartTime", SECONDS, DEFAULT_TIME_FORMAT), Cloudlet::getExecStartTime);
-        addColDataFunction(newColumn("FinishTime", SECONDS, DEFAULT_TIME_FORMAT), Cloudlet::getFinishTime);
-        addColDataFunction(newColumn("ExecTime", SECONDS, DEFAULT_TIME_FORMAT), Cloudlet::getActualCpuTime);
+        addColDataFunction(addColumn("   VM PEs", CPU_CORES, DEFAULT_PE_FORMAT), cloudlet -> cloudlet.getVm().getNumberOfPes());
+        addColDataFunction(addColumn("CloudletLen", MI, DEFAULT_LENGTH_FORMAT), Cloudlet::getLength);
+        addColDataFunction(addColumn("FinishedLen", MI, DEFAULT_LENGTH_FORMAT), Cloudlet::getFinishedLengthSoFar);
+        addColDataFunction(addColumn("CloudletPEs", CPU_CORES, DEFAULT_PE_FORMAT), Cloudlet::getNumberOfPes);
+        addColDataFunction(addColumn("StartTime", SECONDS, DEFAULT_TIME_FORMAT), Cloudlet::getExecStartTime);
+        addColDataFunction(addColumn("FinishTime", SECONDS, DEFAULT_TIME_FORMAT), Cloudlet::getFinishTime);
+        addColDataFunction(addColumn("ExecTime", SECONDS, DEFAULT_TIME_FORMAT), Cloudlet::getActualCpuTime);
     }
 
 }

--- a/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/CloudletsTableBuilder.java
@@ -26,7 +26,6 @@ package org.cloudsimplus.builders.tables;
 import org.cloudbus.cloudsim.cloudlets.Cloudlet;
 import org.cloudbus.cloudsim.core.Identifiable;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**

--- a/src/main/java/org/cloudsimplus/builders/tables/ColumnMapping.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/ColumnMapping.java
@@ -1,0 +1,31 @@
+package org.cloudsimplus.builders.tables;
+
+import java.util.function.Function;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A record that creates a mapping for adding a column into a table latter on.
+ * That is used by {@link TableBuilderAbstract} objects.
+ *
+ * @param <T>          the type of objects printed into the table
+ * @param col          the column to add
+ * @param dataFunction a function that receives an object T and returns the data to be printed from that object
+ * @param index        the index of the column in the table
+ * @author Manoel Campos da Silva Filho
+ * @since CloudSim Plus 7.3.1
+ */
+record ColumnMapping<T>(TableColumn col, Function<T, Object> dataFunction, int index) {
+    public ColumnMapping(TableColumn col, Function<T, Object> dataFunction) {
+        this(col, dataFunction, Integer.MAX_VALUE);
+    }
+
+    ColumnMapping {
+        requireNonNull(col);
+        requireNonNull(dataFunction);
+    }
+
+    public Object getColData(T object){
+        return dataFunction.apply(object);
+    }
+}

--- a/src/main/java/org/cloudsimplus/builders/tables/CsvTable.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/CsvTable.java
@@ -133,9 +133,7 @@ public class CsvTable extends AbstractTable {
     }
 
     @Override
-    public TableColumn addColumn(int index, String columnTitle) {
-        final TableColumn col = new CsvTableColumn(this, columnTitle);
-        getColumns().add(index, col);
-        return col;
+    public TableColumn newColumn(final String title, final String subtitle, final String format) {
+        return new CsvTableColumn(title, subtitle, format);
     }
 }

--- a/src/main/java/org/cloudsimplus/builders/tables/CsvTableColumn.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/CsvTableColumn.java
@@ -36,12 +36,12 @@ public class CsvTableColumn extends AbstractTableColumn {
      */
     public static final String DATA_COL_SEPARATOR_FORMAT = "%s%s";
 
-    public CsvTableColumn(final String title, final String subTitle) {
-        this(null, title, subTitle);
+    public CsvTableColumn(final String title) {
+        this(title, "");
     }
 
-    public CsvTableColumn(final String title) {
-        this(null, title, "");
+    public CsvTableColumn(final String title, final String subTitle) {
+        this(title, subTitle, "");
     }
 
     public CsvTableColumn(final Table table, final String title, final String subTitle) {
@@ -50,6 +50,10 @@ public class CsvTableColumn extends AbstractTableColumn {
 
     public CsvTableColumn(final Table table, final String title) {
         super(table, title);
+    }
+
+    public CsvTableColumn(final String title, final String subTitle, final String format) {
+        super(title, subTitle, format);
     }
 
     @Override

--- a/src/main/java/org/cloudsimplus/builders/tables/HostHistoryTableBuilder.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/HostHistoryTableBuilder.java
@@ -30,7 +30,7 @@ import org.cloudbus.cloudsim.hosts.HostStateHistoryEntry;
  * Builds a table for printing {@link HostStateHistoryEntry} entries from the
  * {@link Host#getStateHistory()}.
  * It defines a set of default columns but new ones can be added
- * dynamically using the {@code addColumn()} methods.
+ * dynamically using the {@code newColumn()} methods.
  *
  * <p>The basic usage of the class is by calling its constructor,
  * giving a Host to print its history, and then

--- a/src/main/java/org/cloudsimplus/builders/tables/HostHistoryTableBuilder.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/HostHistoryTableBuilder.java
@@ -57,24 +57,24 @@ public class HostHistoryTableBuilder extends TableBuilderAbstract<HostStateHisto
     @Override
     protected void createTableColumns() {
         TableColumn col = getTable().addColumn("Time ").setFormat("%5.0f");
-        addColDataFunction(col, HostStateHistoryEntry::time);
+        mapColDataFunction(col, HostStateHistoryEntry::time);
 
         final String format = "%9.0f";
         col = getTable().addColumn("Requested").setFormat(format);
-        addColDataFunction(col, HostStateHistoryEntry::requestedMips);
+        mapColDataFunction(col, HostStateHistoryEntry::requestedMips);
 
         col = getTable().addColumn("Allocated").setFormat(format);
-        addColDataFunction(col, HostStateHistoryEntry::allocatedMips);
+        mapColDataFunction(col, HostStateHistoryEntry::allocatedMips);
 
         col = getTable().addColumn("Used").setFormat("%3.0f%%");
-        addColDataFunction(col, history -> history.percentUsage()*100);
+        mapColDataFunction(col, history -> history.percentUsage()*100);
 
-        addColDataFunction(getTable().addColumn("Host Active"), HostStateHistoryEntry::active);
+        mapColDataFunction(getTable().addColumn("Host Active"), HostStateHistoryEntry::active);
 
         col = getTable().addColumn("Host Total MIPS").setFormat(format);
-        addColDataFunction(col, history -> host.getTotalMipsCapacity());
+        mapColDataFunction(col, history -> host.getTotalMipsCapacity());
 
         col = getTable().addColumn("Host Total Usage").setFormat("%5.1f%%");
-        addColDataFunction(col, history -> history.allocatedMips()/host.getTotalMipsCapacity()*100);
+        mapColDataFunction(col, history -> history.allocatedMips()/host.getTotalMipsCapacity()*100);
     }
 }

--- a/src/main/java/org/cloudsimplus/builders/tables/HostHistoryTableBuilder.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/HostHistoryTableBuilder.java
@@ -30,7 +30,7 @@ import org.cloudbus.cloudsim.hosts.HostStateHistoryEntry;
  * Builds a table for printing {@link HostStateHistoryEntry} entries from the
  * {@link Host#getStateHistory()}.
  * It defines a set of default columns but new ones can be added
- * dynamically using the {@code newColumn()} methods.
+ * dynamically using the {@code addColumn()} methods.
  *
  * <p>The basic usage of the class is by calling its constructor,
  * giving a Host to print its history, and then

--- a/src/main/java/org/cloudsimplus/builders/tables/HostHistoryTableBuilder.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/HostHistoryTableBuilder.java
@@ -30,7 +30,7 @@ import org.cloudbus.cloudsim.hosts.HostStateHistoryEntry;
  * Builds a table for printing {@link HostStateHistoryEntry} entries from the
  * {@link Host#getStateHistory()}.
  * It defines a set of default columns but new ones can be added
- * dynamically using the {@code addColumn()} methods.
+ * dynamically using the {@code newColumn()} methods.
  *
  * <p>The basic usage of the class is by calling its constructor,
  * giving a Host to print its history, and then
@@ -56,25 +56,25 @@ public class HostHistoryTableBuilder extends TableBuilderAbstract<HostStateHisto
 
     @Override
     protected void createTableColumns() {
-        TableColumn col = getTable().addColumn("Time ").setFormat("%5.0f");
+        TableColumn col = getTable().newColumn("Time ").setFormat("%5.0f");
         mapColDataFunction(col, HostStateHistoryEntry::time);
 
         final String format = "%9.0f";
-        col = getTable().addColumn("Requested").setFormat(format);
+        col = getTable().newColumn("Requested").setFormat(format);
         mapColDataFunction(col, HostStateHistoryEntry::requestedMips);
 
-        col = getTable().addColumn("Allocated").setFormat(format);
+        col = getTable().newColumn("Allocated").setFormat(format);
         mapColDataFunction(col, HostStateHistoryEntry::allocatedMips);
 
-        col = getTable().addColumn("Used").setFormat("%3.0f%%");
+        col = getTable().newColumn("Used").setFormat("%3.0f%%");
         mapColDataFunction(col, history -> history.percentUsage()*100);
 
-        mapColDataFunction(getTable().addColumn("Host Active"), HostStateHistoryEntry::active);
+        mapColDataFunction(getTable().newColumn("Host Active"), HostStateHistoryEntry::active);
 
-        col = getTable().addColumn("Host Total MIPS").setFormat(format);
+        col = getTable().newColumn("Host Total MIPS").setFormat(format);
         mapColDataFunction(col, history -> host.getTotalMipsCapacity());
 
-        col = getTable().addColumn("Host Total Usage").setFormat("%5.1f%%");
+        col = getTable().newColumn("Host Total Usage").setFormat("%5.1f%%");
         mapColDataFunction(col, history -> history.allocatedMips()/host.getTotalMipsCapacity()*100);
     }
 }

--- a/src/main/java/org/cloudsimplus/builders/tables/HostHistoryTableBuilder.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/HostHistoryTableBuilder.java
@@ -30,7 +30,7 @@ import org.cloudbus.cloudsim.hosts.HostStateHistoryEntry;
  * Builds a table for printing {@link HostStateHistoryEntry} entries from the
  * {@link Host#getStateHistory()}.
  * It defines a set of default columns but new ones can be added
- * dynamically using the {@code newColumn()} methods.
+ * dynamically using the {@code addColumn()} methods.
  *
  * <p>The basic usage of the class is by calling its constructor,
  * giving a Host to print its history, and then
@@ -56,25 +56,25 @@ public class HostHistoryTableBuilder extends TableBuilderAbstract<HostStateHisto
 
     @Override
     protected void createTableColumns() {
-        TableColumn col = getTable().newColumn("Time ").setFormat("%5.0f");
-        mapColDataFunction(col, HostStateHistoryEntry::time);
+        final var col1 = getTable().newColumn("Time ", "Secs", "%5.0f");
+        addColumn(col1, HostStateHistoryEntry::time);
 
         final String format = "%9.0f";
-        col = getTable().newColumn("Requested").setFormat(format);
-        mapColDataFunction(col, HostStateHistoryEntry::requestedMips);
+        final var col2 = getTable().newColumn("Total Requested", "MIPS", format);
+        addColumn(col2, HostStateHistoryEntry::requestedMips);
 
-        col = getTable().newColumn("Allocated").setFormat(format);
-        mapColDataFunction(col, HostStateHistoryEntry::allocatedMips);
+        final var col3 = getTable().newColumn("Total Allocated", "MIPS", format);
+        addColumn(col3, HostStateHistoryEntry::allocatedMips);
 
-        col = getTable().newColumn("Used").setFormat("%3.0f%%");
-        mapColDataFunction(col, history -> history.percentUsage()*100);
+        final var col4 = getTable().newColumn("Used ", "", "%3.0f%%");
+        addColumn(col4, history -> history.percentUsage()*100);
 
-        mapColDataFunction(getTable().newColumn("Host Active"), HostStateHistoryEntry::active);
+        addColumn(getTable().newColumn("Host Active"), HostStateHistoryEntry::active);
 
-        col = getTable().newColumn("Host Total MIPS").setFormat(format);
-        mapColDataFunction(col, history -> host.getTotalMipsCapacity());
+        final var col5 = getTable().newColumn("Host Total MIPS", "", format);
+        addColumn(col5, history -> host.getTotalMipsCapacity());
 
-        col = getTable().newColumn("Host Total Usage").setFormat("%5.1f%%");
-        mapColDataFunction(col, history -> history.allocatedMips()/host.getTotalMipsCapacity()*100);
+        final var col6 = getTable().newColumn("Host Total Usage", "", "%5.1f%%");
+        addColumn(col6, history -> history.allocatedMips()/host.getTotalMipsCapacity()*100);
     }
 }

--- a/src/main/java/org/cloudsimplus/builders/tables/HtmlTable.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/HtmlTable.java
@@ -73,9 +73,7 @@ public class HtmlTable extends AbstractTable {
     }
 
     @Override
-    public TableColumn addColumn(int index, String columnTitle) {
-        final TableColumn col = new HtmlTableColumn(this, columnTitle);
-        getColumns().add(index, col);
-        return col;
+    public TableColumn newColumn(final String title, final String subtitle, final String format) {
+        return new HtmlTableColumn(title, subtitle, format);
     }
 }

--- a/src/main/java/org/cloudsimplus/builders/tables/HtmlTableColumn.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/HtmlTableColumn.java
@@ -32,11 +32,11 @@ package org.cloudsimplus.builders.tables;
  */
 public class HtmlTableColumn extends AbstractTableColumn {
     public HtmlTableColumn(final String title, final String subTitle) {
-        this(null, title, subTitle);
+        this(title, subTitle, "");
     }
 
     public HtmlTableColumn(final String title) {
-        this(null, title, "");
+        this(title, "", "");
     }
 
     public HtmlTableColumn(final Table table, final String title) {
@@ -45,6 +45,10 @@ public class HtmlTableColumn extends AbstractTableColumn {
 
     public HtmlTableColumn(final Table table, final String title, final String subTitle) {
         super(table, title, subTitle);
+    }
+
+    public HtmlTableColumn(final String title, final String subTitle, final String format) {
+        super(title, subTitle, format);
     }
 
     private String indentLine(final int columnIndex) {

--- a/src/main/java/org/cloudsimplus/builders/tables/MarkdownTable.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/MarkdownTable.java
@@ -75,7 +75,7 @@ public class MarkdownTable extends CsvTable {
     }
 
     @Override
-    public TableColumn addColumn(final int index, final String columnTitle) {
-        return addColumn(new MarkdownTableColumn(this, columnTitle));
+    public TableColumn newColumn(final String title, final String subtitle, final String format) {
+        return new MarkdownTableColumn(title, subtitle, format);
     }
 }

--- a/src/main/java/org/cloudsimplus/builders/tables/MarkdownTableColumn.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/MarkdownTableColumn.java
@@ -32,11 +32,11 @@ package org.cloudsimplus.builders.tables;
  */
 public class MarkdownTableColumn extends CsvTableColumn {
     public MarkdownTableColumn(final String title, final String subTitle) {
-        this(null, title, subTitle);
+        this(title, subTitle, "");
     }
 
     public MarkdownTableColumn(final String title) {
-        this(null, title, "");
+        this(title, "", "");
     }
 
     public MarkdownTableColumn(final Table table, final String title, final String subTitle) {
@@ -45,6 +45,10 @@ public class MarkdownTableColumn extends CsvTableColumn {
 
     public MarkdownTableColumn(final Table table, final String title) {
         super(table, title);
+    }
+
+    public MarkdownTableColumn(final String title, final String subTitle, final String format) {
+        super(title, subTitle, format);
     }
 
     @Override

--- a/src/main/java/org/cloudsimplus/builders/tables/Table.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/Table.java
@@ -134,6 +134,13 @@ public interface Table {
     List<TableColumn> getColumns();
 
     /**
+     * Gets the number of columns.
+     *
+     * @return
+     */
+    int colCount();
+
+    /**
      * Gets the string used to separate one column from another (optional).
      * @return
      */

--- a/src/main/java/org/cloudsimplus/builders/tables/Table.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/Table.java
@@ -48,7 +48,7 @@ public interface Table {
      * @see #addColumn(int, TableColumn)
      * @see #addColumn(String, String, String)
      */
-    TableColumn addColumn(String columnTitle);
+    TableColumn newColumn(String columnTitle);
 
     /**
      * Adds a column with a given title to the end of the table's columns to be printed.
@@ -56,7 +56,7 @@ public interface Table {
      * @param index the position to insert the column into the column's list
      * @param columnTitle The title of the column to be added.
      * @return the created column
-     * @see #addColumn(String)
+     * @see #newColumn(String)
      * @see #addColumn(int, TableColumn)
      * @see #addColumn(String, String, String)
      */
@@ -68,7 +68,7 @@ public interface Table {
      * @param columnTitle The title of the column to be added.
      * @param columnSubTitle The subtitle of the column to be added.
      * @return the created column
-     * @see #addColumn(String)
+     * @see #newColumn(String)
      * @see #addColumn(int, String)
      * @see #addColumn(String, String, String)
      */
@@ -81,7 +81,7 @@ public interface Table {
      * @param columnSubTitle The subtitle of the column to be added.
      * @param format format to print the column data
      * @return the created column
-     * @see #addColumn(String)
+     * @see #newColumn(String)
      * @see #addColumn(int, String)
      * @see #addColumn(int, TableColumn)
      */
@@ -111,7 +111,7 @@ public interface Table {
      *
      * @param columnTitles The titles of the columns
      * @return the {@link Table} instance.
-     * @see #addColumn(String)
+     * @see #newColumn(String)
      */
     Table addColumnList(String... columnTitles);
 

--- a/src/main/java/org/cloudsimplus/builders/tables/Table.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/Table.java
@@ -63,10 +63,10 @@ public interface Table {
     TableColumn addColumn(int index, String columnTitle);
 
     /**
-     * Adds a column with a given title and sub-title to the end of the table's columns to be printed.
+     * Adds a column with a given title and subtitle to the end of the table's columns to be printed.
      *
      * @param columnTitle The title of the column to be added.
-     * @param columnSubTitle The sub-title of the column to be added.
+     * @param columnSubTitle The subtitle of the column to be added.
      * @return the created column
      * @see #addColumn(String)
      * @see #addColumn(int, String)
@@ -75,10 +75,10 @@ public interface Table {
     TableColumn addColumn(String columnTitle, String columnSubTitle);
 
     /**
-     * Adds a column with a given title and sub-title to the end of the table's columns to be printed.
+     * Adds a column with a given title and subtitle to the end of the table's columns to be printed.
      *
      * @param columnTitle The title of the column to be added.
-     * @param columnSubTitle The sub-title of the column to be added.
+     * @param columnSubTitle The subtitle of the column to be added.
      * @param format format to print the column data
      * @return the created column
      * @see #addColumn(String)

--- a/src/main/java/org/cloudsimplus/builders/tables/Table.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/Table.java
@@ -40,69 +40,40 @@ public interface Table {
     List<Object> newRow();
 
     /**
-     * Adds a column with a given to the end of the table's columns to be printed.
+     * Creates a column with a given title.
+     * The created column is not added to the table.
      *
-     * @param columnTitle The title of the column to be added.
+     * @param title The title of the column to create.
      * @return The created column.
-     * @see #addColumn(int, String)
-     * @see #addColumn(int, TableColumn)
-     * @see #addColumn(String, String, String)
+     * @see #newColumn(String, String)
+     * @see #newColumn(String, String, String)
      */
-    TableColumn newColumn(String columnTitle);
+    TableColumn newColumn(String title);
 
     /**
-     * Adds a column with a given title to the end of the table's columns to be printed.
+     * Creates a column with a given title and subtitle.
+     * The created column is not added to the table.
      *
-     * @param index the position to insert the column into the column's list
-     * @param columnTitle The title of the column to be added.
+     * @param title The title of the column to be added.
+     * @param subTitle The subtitle of the column to be added.
      * @return the created column
      * @see #newColumn(String)
-     * @see #addColumn(int, TableColumn)
-     * @see #addColumn(String, String, String)
+     * @see #newColumn(String, String, String)
      */
-    TableColumn addColumn(int index, String columnTitle);
+    TableColumn newColumn(String title, String subTitle);
 
     /**
-     * Adds a column with a given title and subtitle to the end of the table's columns to be printed.
+     * Cretes a column with a given title, subtitle and format.
+     * The created column is not added to the table.
      *
-     * @param columnTitle The title of the column to be added.
-     * @param columnSubTitle The subtitle of the column to be added.
-     * @return the created column
-     * @see #newColumn(String)
-     * @see #addColumn(int, String)
-     * @see #addColumn(String, String, String)
-     */
-    TableColumn addColumn(String columnTitle, String columnSubTitle);
-
-    /**
-     * Adds a column with a given title and subtitle to the end of the table's columns to be printed.
-     *
-     * @param columnTitle The title of the column to be added.
-     * @param columnSubTitle The subtitle of the column to be added.
+     * @param title The title of the column to be added.
+     * @param subtitle The subtitle of the column to be added.
      * @param format format to print the column data
      * @return the created column
      * @see #newColumn(String)
-     * @see #addColumn(int, String)
-     * @see #addColumn(int, TableColumn)
+     * @see #newColumn(String, String)
      */
-    TableColumn addColumn(String columnTitle, String columnSubTitle, String format);
-
-    /**
-     * Adds a column object to a specific position of the table's columns to be printed.
-     *
-     * @param index the position to insert the column into the column's list
-     * @param column The column to be added.
-     * @return the created column
-     */
-    TableColumn addColumn(int index, TableColumn column);
-
-    /**
-     * Adds a column object to the end of the table's columns to be printed.
-     *
-     * @param column The column to be added.
-     * @return the created column
-     */
-    TableColumn addColumn(TableColumn column);
+    TableColumn newColumn(String title, String subtitle, String format);
 
     /**
      * Adds a list of columns (with given titles) to the end of the

--- a/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
@@ -206,7 +206,7 @@ public abstract class TableBuilderAbstract<T> {
      */
     public TableBuilderAbstract<T> setFormatByTitle(final String title, final String format){
     	for(TableColumn col : getTable().getColumns()) {
-    		if(col.getTitle().trim() == title.trim()) {
+    		if(col.getTitle().trim().equals(title.trim())) {
     			col.setFormat(format);
     		}
     	}

--- a/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
@@ -73,7 +73,6 @@ public abstract class TableBuilderAbstract<T> {
         setTable(table);
         setObjectList(list);
         colsDataFunctions = new HashMap<>();
-        createTableColumns();
     }
 
     /**
@@ -180,6 +179,11 @@ public abstract class TableBuilderAbstract<T> {
      * Builds the table with the data from the list of objects and shows the results.
      */
     public void build(){
+    	
+    	// TODO: Building table columns here instead of in the constructor solves the issues with variables not
+    	// being initialized but creates problems when trying to expand the table using addColumn() before building.
+    	createTableColumns();
+    	
         if(getTable().getTitle().isEmpty()){
             getTable().setTitle("SIMULATION RESULTS");
         }

--- a/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
@@ -206,11 +206,7 @@ public abstract class TableBuilderAbstract<T> {
      * @return
      */
     public TableBuilderAbstract<T> setFormatByTitle(final String title, final String format){
-        columnsForEach(
-            col -> col.matchTitle(title),
-            col -> col.setFormat(format)
-        );
-
+        setColumnsFormat(col -> col.matchTitle(title), format);
     	return this;
     }
 
@@ -221,24 +217,21 @@ public abstract class TableBuilderAbstract<T> {
      * @return
      */
     public TableBuilderAbstract<T> setFormatBySubTitle(final String subTitle, final String format){
-        columnsForEach(
-            col -> col.matchSubTitle(subTitle),
-            col -> col.setFormat(format)
-        );
-
+        setColumnsFormat(col -> col.matchSubTitle(subTitle), format);
     	return this;
     }
 
     /**
      * Iterate over the columns of the table that match
-     * a given {@link Predicate} and execute the operations defined
-     * by a given {@link Consumer}.
+     * a given {@link Predicate} and sets their format to a given value.
+     * @param predicate the {@link Predicate} to filter columns to apply format
+     * @param format the format to set for matching columns
      */
-    protected void columnsForEach(final Predicate<TableColumn> predicate, final Consumer<TableColumn> consumer){
+    protected void setColumnsFormat(final Predicate<TableColumn> predicate, final String format){
         table.getColumns()
              .stream()
              .filter(predicate)
-             .forEach(consumer);
+             .forEach(col -> col.setFormat(format));
     }
 
     /**

--- a/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
@@ -191,7 +191,7 @@ public abstract class TableBuilderAbstract<T> {
      * @return
      */
     public TableBuilderAbstract<T> setFormatByIndex(final String format, final int ...indices) {
-    	for(int index : indices) {
+    	for(final int index : indices) {
     		getColumn(index).setFormat(format);
     	}
     	return this;

--- a/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
@@ -127,7 +127,7 @@ public abstract class TableBuilderAbstract<T> {
      * @return
      */
     public TableBuilderAbstract<T> addColumn(final TableColumn col, final Function<T, Object> dataFunction){
-        return addColumn(getTable().colCount(), col, dataFunction);
+        return addColumn(table.colCount(), col, dataFunction);
     }
 
     /**
@@ -164,7 +164,7 @@ public abstract class TableBuilderAbstract<T> {
      * @return the created column
      */
     protected TableColumn newColumn(final String title, final String subtitle, final String format) {
-        return getTable().addColumn(title, subtitle, format);
+        return table.addColumn(title, subtitle, format);
     }
 
     private TableColumn getColumn(final int index) {
@@ -281,7 +281,7 @@ public abstract class TableBuilderAbstract<T> {
      * @param row The row that the data from the object T will be added to
      */
     protected void addDataToRow(final T object, final List<Object> row) {
-        getTable()
+        table
             .getColumns()
             .forEach(col -> row.add(colsDataFunctions.get(col).apply(object)));
     }

--- a/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
@@ -130,7 +130,28 @@ public abstract class TableBuilderAbstract<T> {
     }
 
     /**
-     * Dynamically adds a column to a specific position into the table to be built.
+     * Creates a column at the end of the table to be built.
+     * @param title The title of the column to be added.
+     * @param subtitle The subtitle of the column to be added.
+     * @return the created column
+     */
+    protected TableColumn newColumn(final String title, final String subtitle) {
+        return newColumn(title, subtitle, "");
+    }
+
+    /**
+     * Creates a column at the end of the table to be built.
+     * @param title The title of the column to be added.
+     * @param subtitle The subtitle of the column to be added.
+     * @param format format to print the column data
+     * @return the created column
+     */
+    protected TableColumn newColumn(final String title, final String subtitle, final String format) {
+        return getTable().addColumn(title, subtitle, format);
+    }
+
+    /**
+     * Adds a column to a specific position into the table to be built.
      * @param index the position to insert the column.
      * @param col the column to add
      * @param dataFunction a function that receives a Cloudlet and returns the data to be printed for the added column

--- a/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
@@ -205,7 +205,7 @@ public abstract class TableBuilderAbstract<T> {
      * @return
      */
     public TableBuilderAbstract<T> setFormatByTitle(final String title, final String format){
-    	for(TableColumn col : getTable().getColumns()) {
+    	for(final var col : getTable().getColumns()) {
     		if(col.getTitle().trim().equals(title.trim())) {
     			col.setFormat(format);
     		}

--- a/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import static java.util.Objects.requireNonNull;
 
@@ -205,11 +206,11 @@ public abstract class TableBuilderAbstract<T> {
      * @return
      */
     public TableBuilderAbstract<T> setFormatByTitle(final String title, final String format){
-    	for(final var col : getTable().getColumns()) {
-    		if(col.getTitle().trim().equals(title.trim())) {
-    			col.setFormat(format);
-    		}
-    	}
+        columnsForEach(
+            col -> col.matchTitle(title),
+            col -> col.setFormat(format)
+        );
+
     	return this;
     }
 
@@ -220,12 +221,24 @@ public abstract class TableBuilderAbstract<T> {
      * @return
      */
     public TableBuilderAbstract<T> setFormatBySubTitle(final String subTitle, final String format){
-    	for(TableColumn col : getTable().getColumns()) {
-    		if(col.getSubTitle().trim() == subTitle.trim()) {
-    			col.setFormat(format);
-    		}
-    	}
+        columnsForEach(
+            col -> col.matchSubTitle(subTitle),
+            col -> col.setFormat(format)
+        );
+
     	return this;
+    }
+
+    /**
+     * Iterate over the columns of the table that match
+     * a given {@link Predicate} and execute the operations defined
+     * by a given {@link Consumer}.
+     */
+    protected void columnsForEach(final Predicate<TableColumn> predicate, final Consumer<TableColumn> consumer){
+        table.getColumns()
+             .stream()
+             .filter(predicate)
+             .forEach(consumer);
     }
 
     /**

--- a/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
@@ -64,7 +64,7 @@ public abstract class TableBuilderAbstract<T> {
     }
 
     /**
-     * Instantiates a builder to print the list of objects T using the a
+     * Instantiates a builder to print the list of objects T using a
      * given {@link Table}.
      *
      * @param list the list of objects T to print

--- a/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
@@ -147,9 +147,9 @@ public abstract class TableBuilderAbstract<T> {
     }
     
     /**
-     * TODO: Docs
-     * @param index
-     * @param format
+     * Sets the formatting for one column.
+     * @param index The index of the target column.
+     * @param format The new formatting string.
      * @return
      */
     public TableBuilderAbstract<T> setFormatByIndex(int index, String format) {
@@ -158,9 +158,9 @@ public abstract class TableBuilderAbstract<T> {
     }
     
     /**
-     * TODO: Docs
-     * @param index
-     * @param format
+     * Sets the formatting for multiple columns.
+     * @param index The list of indices for all target columns.
+     * @param format The new formatting string.
      * @return
      */
     public TableBuilderAbstract<T> setFormatByIndex(int[] indices, String format) {
@@ -171,9 +171,10 @@ public abstract class TableBuilderAbstract<T> {
     }
     
     /**
-     * 
-     * @param title
-     * @param format
+     * Sets the formatting for the column with a specific title.
+     * If multiple columns have the same title then all columns will be changed.
+     * @param title The title of the target column(s).
+     * @param format The new formatting string.
      * @return
      */
     public TableBuilderAbstract<T> setFormatByTitle(String title, String format){
@@ -186,9 +187,9 @@ public abstract class TableBuilderAbstract<T> {
     }
     
     /**
-     * 
-     * @param title
-     * @param format
+     * Sets the formatting for all columns with a specific subtitle.
+     * @param title The subtitle of the target column(s)
+     * @param format The new formatting string.
      * @return
      */
     public TableBuilderAbstract<T> setFormatBySubTitle(String subTitle, String format){

--- a/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
@@ -234,7 +234,6 @@ public abstract class TableBuilderAbstract<T> {
      * Builds the table with the data from the list of objects and shows the results.
      */
     public void build(){
-    	
         if(getTable().getTitle().isEmpty()){
             getTable().setTitle("SIMULATION RESULTS");
         }

--- a/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
@@ -153,8 +153,12 @@ public abstract class TableBuilderAbstract<T> {
      * @return
      */
     public TableBuilderAbstract<T> setFormatByIndex(final int index, final String format) {
-    	getTable().getColumns().get(index).setFormat(format);
+    	getColumn(index).setFormat(format);
     	return this;
+    }
+
+    private TableColumn getColumn(final int index) {
+        return getTable().getColumns().get(index);
     }
 
     /**
@@ -165,7 +169,7 @@ public abstract class TableBuilderAbstract<T> {
      */
     public TableBuilderAbstract<T> setFormatByIndex(final int[] indices, final String format) {
     	for(int index : indices) {
-    		getTable().getColumns().get(index).setFormat(format);
+    		getColumn(index).setFormat(format);
     	}
     	return this;
     }

--- a/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
@@ -73,6 +73,7 @@ public abstract class TableBuilderAbstract<T> {
         setTable(table);
         setObjectList(list);
         colsDataFunctions = new HashMap<>();
+        createTableColumns();
     }
 
     /**
@@ -144,6 +145,30 @@ public abstract class TableBuilderAbstract<T> {
         colsDataFunctions.put(col, dataFunction);
         return this;
     }
+    
+    /**
+     * TODO: Docs
+     * @param index
+     * @param format
+     * @return
+     */
+    public TableBuilderAbstract<T> setFormatForColumn(int index, String format) {
+    	getTable().getColumns().get(index).setFormat(format);
+    	return this;
+    }
+    
+    /**
+     * TODO: Docs
+     * @param index
+     * @param format
+     * @return
+     */
+    public TableBuilderAbstract<T> setFormatForColumns(int[] indices, String format) {
+    	for(int index : indices) {
+    		getTable().getColumns().get(index).setFormat(format);
+    	}
+    	return this;
+    }
 
     /**
      * Removes columns from given positions.
@@ -179,10 +204,6 @@ public abstract class TableBuilderAbstract<T> {
      * Builds the table with the data from the list of objects and shows the results.
      */
     public void build(){
-    	
-    	// TODO: Building table columns here instead of in the constructor solves the issues with variables not
-    	// being initialized but creates problems when trying to expand the table using addColumn() before building.
-    	createTableColumns();
     	
         if(getTable().getTitle().isEmpty()){
             getTable().setTitle("SIMULATION RESULTS");

--- a/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
@@ -173,22 +173,24 @@ public abstract class TableBuilderAbstract<T> {
 
     /**
      * Sets the formatting for one column.
-     * @param index the index of the target column.
+     *
      * @param format the new formatting string.
+     * @param index  the index of the target column.
      * @return
      */
-    public TableBuilderAbstract<T> setFormatByIndex(final int index, final String format) {
+    public TableBuilderAbstract<T> setFormatByIndex(final String format, final int index) {
     	getColumn(index).setFormat(format);
     	return this;
     }
 
     /**
      * Sets the formatting for multiple columns.
+     *
+     * @param format  the new formatting string.
      * @param indices the list of indices for all target columns.
-     * @param format the new formatting string.
      * @return
      */
-    public TableBuilderAbstract<T> setFormatByIndex(final int[] indices, final String format) {
+    public TableBuilderAbstract<T> setFormatByIndex(final String format, final int[] indices) {
     	for(int index : indices) {
     		getColumn(index).setFormat(format);
     	}

--- a/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
@@ -162,7 +162,6 @@ public abstract class TableBuilderAbstract<T> {
         requireNonNull(col);
         requireNonNull(dataFunction);
 
-        col.setTable(getTable());
         getTable().addColumn(index, col);
         colsDataFunctions.put(col, dataFunction);
         return this;

--- a/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
@@ -71,7 +71,6 @@ public abstract class TableBuilderAbstract<T> {
         setTable(table);
         setObjectList(list);
         colsMappings = new ArrayList<>();
-        createTableColumns();
     }
 
     /**
@@ -231,15 +230,11 @@ public abstract class TableBuilderAbstract<T> {
     }
 
     /**
-     * Creates the columns of the table and define how the data for those columns
-     * will be got from an object inside the {@link #list} of objects to be printed.
-     */
-    protected abstract void createTableColumns();
-
-    /**
      * Builds the table with the data from the list of objects and shows the results.
      */
     public void build(){
+        createAndAddTableColumns();
+
         if(table.getTitle().isEmpty()){
             table.setTitle("SIMULATION RESULTS");
         }
@@ -247,6 +242,25 @@ public abstract class TableBuilderAbstract<T> {
         list.forEach(cloudlet -> addDataToRow(cloudlet, table.newRow()));
         table.print();
     }
+
+    private void createAndAddTableColumns() {
+        if(!colsMappings.isEmpty()) {
+            return;
+        }
+
+        createTableColumns();
+
+        final var tb = (AbstractTable)table;
+        colsMappings.forEach(mapping -> tb.addColumn(mapping.col(), mapping.index()));
+    }
+
+    /**
+     * Creates the columns of the table and define how the data for those columns
+     * will be got from an object inside the {@link #list} of objects to be printed.
+     * It doesn't add such columns into a table yet.
+     * @see #createAndAddTableColumns()
+     */
+    protected abstract void createTableColumns();
 
     /**
      * Add data to a row of the table being generated.

--- a/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
@@ -187,10 +187,10 @@ public abstract class TableBuilderAbstract<T> {
      * Sets the formatting for multiple columns.
      *
      * @param format  the new formatting string.
-     * @param indices the list of indices for all target columns.
+     * @param indices indices for all target columns.
      * @return
      */
-    public TableBuilderAbstract<T> setFormatByIndex(final String format, final int[] indices) {
+    public TableBuilderAbstract<T> setFormatByIndex(final String format, final int ...indices) {
     	for(int index : indices) {
     		getColumn(index).setFormat(format);
     	}

--- a/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
@@ -126,7 +126,7 @@ public abstract class TableBuilderAbstract<T> {
      * @return
      */
     public TableBuilderAbstract<T> addColumn(final TableColumn col, final Function<T, Object> dataFunction){
-        return addColumn(getTable().getColumns().size(), col, dataFunction);
+        return addColumn(getTable().colCount(), col, dataFunction);
     }
 
     /**

--- a/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
@@ -152,7 +152,7 @@ public abstract class TableBuilderAbstract<T> {
      * @param format
      * @return
      */
-    public TableBuilderAbstract<T> setFormatForColumn(int index, String format) {
+    public TableBuilderAbstract<T> setFormatByIndex(int index, String format) {
     	getTable().getColumns().get(index).setFormat(format);
     	return this;
     }
@@ -163,9 +163,39 @@ public abstract class TableBuilderAbstract<T> {
      * @param format
      * @return
      */
-    public TableBuilderAbstract<T> setFormatForColumns(int[] indices, String format) {
+    public TableBuilderAbstract<T> setFormatByIndex(int[] indices, String format) {
     	for(int index : indices) {
     		getTable().getColumns().get(index).setFormat(format);
+    	}
+    	return this;
+    }
+    
+    /**
+     * 
+     * @param title
+     * @param format
+     * @return
+     */
+    public TableBuilderAbstract<T> setFormatByTitle(String title, String format){
+    	for(TableColumn col : getTable().getColumns()) {
+    		if(col.getTitle() == title) {
+    			col.setFormat(format);
+    		}
+    	}
+    	return this;
+    }
+    
+    /**
+     * 
+     * @param title
+     * @param format
+     * @return
+     */
+    public TableBuilderAbstract<T> setFormatBySubTitle(String subTitle, String format){
+    	for(TableColumn col : getTable().getColumns()) {
+    		if(col.getSubTitle() == subTitle) {
+    			col.setFormat(format);
+    		}
     	}
     	return this;
     }

--- a/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
@@ -167,6 +167,10 @@ public abstract class TableBuilderAbstract<T> {
         return this;
     }
 
+    private TableColumn getColumn(final int index) {
+        return getTable().getColumns().get(index);
+    }
+
     /**
      * Sets the formatting for one column.
      * @param index the index of the target column.
@@ -176,10 +180,6 @@ public abstract class TableBuilderAbstract<T> {
     public TableBuilderAbstract<T> setFormatByIndex(final int index, final String format) {
     	getColumn(index).setFormat(format);
     	return this;
-    }
-
-    private TableColumn getColumn(final int index) {
-        return getTable().getColumns().get(index);
     }
 
     /**

--- a/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
@@ -287,13 +287,13 @@ public abstract class TableBuilderAbstract<T> {
     }
 
     /**
-     * Adds a data function for a given column.
-     * @param col column to add a data function
+     * Creates a mapping between a column and a function to display the column data.
+     * @param col column to map a data function to
      * @param dataFunction a function that receives an object T and returns the data to be printed from that object.
      * @return
      * @see #colsDataFunctions
      */
-    protected TableBuilderAbstract<T> addColDataFunction(final TableColumn col, final Function<T, Object> dataFunction){
+    protected TableBuilderAbstract<T> mapColDataFunction(final TableColumn col, final Function<T, Object> dataFunction){
         colsDataFunctions.put(requireNonNull(col), requireNonNull(dataFunction));
         return this;
     }

--- a/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
@@ -152,8 +152,8 @@ public abstract class TableBuilderAbstract<T> {
      * @param subtitle The subtitle of the column to be added.
      * @return the created column
      */
-    protected TableColumn newColumn(final String title, final String subtitle) {
-        return newColumn(title, subtitle, "");
+    protected TableColumn addColumn(final String title, final String subtitle) {
+        return addColumn(title, subtitle, "");
     }
 
     /**
@@ -163,7 +163,7 @@ public abstract class TableBuilderAbstract<T> {
      * @param format format to print the column data
      * @return the created column
      */
-    protected TableColumn newColumn(final String title, final String subtitle, final String format) {
+    protected TableColumn addColumn(final String title, final String subtitle, final String format) {
         return table.addColumn(title, subtitle, format);
     }
 

--- a/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
@@ -179,7 +179,7 @@ public abstract class TableBuilderAbstract<T> {
      */
     public TableBuilderAbstract<T> setFormatByTitle(String title, String format){
     	for(TableColumn col : getTable().getColumns()) {
-    		if(col.getTitle() == title) {
+    		if(col.getTitle().trim() == title.trim()) {
     			col.setFormat(format);
     		}
     	}
@@ -194,7 +194,7 @@ public abstract class TableBuilderAbstract<T> {
      */
     public TableBuilderAbstract<T> setFormatBySubTitle(String subTitle, String format){
     	for(TableColumn col : getTable().getColumns()) {
-    		if(col.getSubTitle() == subTitle) {
+    		if(col.getSubTitle().trim() == subTitle.trim()) {
     			col.setFormat(format);
     		}
     	}

--- a/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
@@ -152,7 +152,7 @@ public abstract class TableBuilderAbstract<T> {
      * @param format the new formatting string.
      * @return
      */
-    public TableBuilderAbstract<T> setFormatByIndex(int index, String format) {
+    public TableBuilderAbstract<T> setFormatByIndex(final int index, final String format) {
     	getTable().getColumns().get(index).setFormat(format);
     	return this;
     }
@@ -163,7 +163,7 @@ public abstract class TableBuilderAbstract<T> {
      * @param format the new formatting string.
      * @return
      */
-    public TableBuilderAbstract<T> setFormatByIndex(int[] indices, String format) {
+    public TableBuilderAbstract<T> setFormatByIndex(final int[] indices, final String format) {
     	for(int index : indices) {
     		getTable().getColumns().get(index).setFormat(format);
     	}
@@ -177,7 +177,7 @@ public abstract class TableBuilderAbstract<T> {
      * @param format the new formatting string.
      * @return
      */
-    public TableBuilderAbstract<T> setFormatByTitle(String title, String format){
+    public TableBuilderAbstract<T> setFormatByTitle(final String title, final String format){
     	for(TableColumn col : getTable().getColumns()) {
     		if(col.getTitle().trim() == title.trim()) {
     			col.setFormat(format);
@@ -192,7 +192,7 @@ public abstract class TableBuilderAbstract<T> {
      * @param format the new formatting string.
      * @return
      */
-    public TableBuilderAbstract<T> setFormatBySubTitle(String subTitle, String format){
+    public TableBuilderAbstract<T> setFormatBySubTitle(final String subTitle, final String format){
     	for(TableColumn col : getTable().getColumns()) {
     		if(col.getSubTitle().trim() == subTitle.trim()) {
     			col.setFormat(format);

--- a/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
@@ -145,22 +145,22 @@ public abstract class TableBuilderAbstract<T> {
         colsDataFunctions.put(col, dataFunction);
         return this;
     }
-    
+
     /**
      * Sets the formatting for one column.
-     * @param index The index of the target column.
-     * @param format The new formatting string.
+     * @param index the index of the target column.
+     * @param format the new formatting string.
      * @return
      */
     public TableBuilderAbstract<T> setFormatByIndex(int index, String format) {
     	getTable().getColumns().get(index).setFormat(format);
     	return this;
     }
-    
+
     /**
      * Sets the formatting for multiple columns.
-     * @param index The list of indices for all target columns.
-     * @param format The new formatting string.
+     * @param indices the list of indices for all target columns.
+     * @param format the new formatting string.
      * @return
      */
     public TableBuilderAbstract<T> setFormatByIndex(int[] indices, String format) {
@@ -169,12 +169,12 @@ public abstract class TableBuilderAbstract<T> {
     	}
     	return this;
     }
-    
+
     /**
      * Sets the formatting for the column with a specific title.
      * If multiple columns have the same title then all columns will be changed.
-     * @param title The title of the target column(s).
-     * @param format The new formatting string.
+     * @param title the title of the target column(s).
+     * @param format the new formatting string.
      * @return
      */
     public TableBuilderAbstract<T> setFormatByTitle(String title, String format){
@@ -185,11 +185,11 @@ public abstract class TableBuilderAbstract<T> {
     	}
     	return this;
     }
-    
+
     /**
      * Sets the formatting for all columns with a specific subtitle.
-     * @param title The subtitle of the target column(s)
-     * @param format The new formatting string.
+     * @param subTitle the subtitle of the target column(s).
+     * @param format the new formatting string.
      * @return
      */
     public TableBuilderAbstract<T> setFormatBySubTitle(String subTitle, String format){
@@ -203,7 +203,7 @@ public abstract class TableBuilderAbstract<T> {
 
     /**
      * Removes columns from given positions.
-     * @param indexes the indexes of the columns to remove
+     * @param indexes the indexes of the columns to remove.
      * @return
      * @see #removeColumn(int)
      */
@@ -216,7 +216,7 @@ public abstract class TableBuilderAbstract<T> {
 
     /**
      * Removes a column from a given position.
-     * @param index the index of the column to remove
+     * @param index the index of the column to remove.
      * @return
      * @see #removeColumn(int...)
      */

--- a/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
@@ -131,6 +131,22 @@ public abstract class TableBuilderAbstract<T> {
     }
 
     /**
+     * Adds a column to a specific position into the table to be built.
+     * @param index the position to insert the column.
+     * @param col the column to add
+     * @param dataFunction a function that receives a Cloudlet and returns the data to be printed for the added column
+     * @return
+     */
+    public TableBuilderAbstract<T> addColumn(final int index, final TableColumn col, final Function<T, Object> dataFunction){
+        requireNonNull(col);
+        requireNonNull(dataFunction);
+
+        table.addColumn(index, col);
+        colsDataFunctions.put(col, dataFunction);
+        return this;
+    }
+
+    /**
      * Creates a column at the end of the table to be built.
      * @param title The title of the column to be added.
      * @param subtitle The subtitle of the column to be added.
@@ -149,22 +165,6 @@ public abstract class TableBuilderAbstract<T> {
      */
     protected TableColumn newColumn(final String title, final String subtitle, final String format) {
         return getTable().addColumn(title, subtitle, format);
-    }
-
-    /**
-     * Adds a column to a specific position into the table to be built.
-     * @param index the position to insert the column.
-     * @param col the column to add
-     * @param dataFunction a function that receives a Cloudlet and returns the data to be printed for the added column
-     * @return
-     */
-    public TableBuilderAbstract<T> addColumn(final int index, final TableColumn col, final Function<T, Object> dataFunction){
-        requireNonNull(col);
-        requireNonNull(dataFunction);
-
-        table.addColumn(index, col);
-        colsDataFunctions.put(col, dataFunction);
-        return this;
     }
 
     private TableColumn getColumn(final int index) {

--- a/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
@@ -147,7 +147,7 @@ public abstract class TableBuilderAbstract<T> {
     }
 
     /**
-     * Creates a column at the end of the table to be built.
+     * Adds a column at the end of the table to be built.
      * @param title The title of the column to be added.
      * @param subtitle The subtitle of the column to be added.
      * @return the created column
@@ -157,7 +157,7 @@ public abstract class TableBuilderAbstract<T> {
     }
 
     /**
-     * Creates a column at the end of the table to be built.
+     * Adds a column at the end of the table to be built.
      * @param title The title of the column to be added.
      * @param subtitle The subtitle of the column to be added.
      * @param format format to print the column data

--- a/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
@@ -162,13 +162,13 @@ public abstract class TableBuilderAbstract<T> {
         requireNonNull(col);
         requireNonNull(dataFunction);
 
-        getTable().addColumn(index, col);
+        table.addColumn(index, col);
         colsDataFunctions.put(col, dataFunction);
         return this;
     }
 
     private TableColumn getColumn(final int index) {
-        return getTable().getColumns().get(index);
+        return table.getColumns().get(index);
     }
 
     /**
@@ -253,7 +253,7 @@ public abstract class TableBuilderAbstract<T> {
      * @see #removeColumn(int...)
      */
     public final TableBuilderAbstract<T> removeColumn(final int index){
-        getTable().getColumns().remove(index);
+        table.getColumns().remove(index);
         return this;
     }
 
@@ -267,12 +267,12 @@ public abstract class TableBuilderAbstract<T> {
      * Builds the table with the data from the list of objects and shows the results.
      */
     public void build(){
-        if(getTable().getTitle().isEmpty()){
-            getTable().setTitle("SIMULATION RESULTS");
+        if(table.getTitle().isEmpty()){
+            table.setTitle("SIMULATION RESULTS");
         }
 
-        list.forEach(cloudlet -> addDataToRow(cloudlet, getTable().newRow()));
-        getTable().print();
+        list.forEach(cloudlet -> addDataToRow(cloudlet, table.newRow()));
+        table.print();
     }
 
     /**

--- a/src/main/java/org/cloudsimplus/builders/tables/TableColumn.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/TableColumn.java
@@ -79,6 +79,14 @@ public interface TableColumn {
     String getTitle();
 
     /**
+     * Checks if the column title matches with a given title,
+     * regardless of left and right spaces.
+     * @param title the title to compare the column to
+     * @return true if the column title matches, false otherwise.
+     */
+    boolean matchTitle(String title);
+
+    /**
      * Sets the format to print the column data
      * @param format the format to set
      * @return

--- a/src/main/java/org/cloudsimplus/builders/tables/TableColumn.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/TableColumn.java
@@ -80,9 +80,9 @@ public interface TableColumn {
 
     /**
      * Checks if the column title matches with a given title,
-     * regardless of left and right spaces.
+     * ignoring left and right spaces (padding).
      * @param title the title to compare the column to
-     * @return true if the column title matches, false otherwise.
+     * @return true if the column title matches ignoring padding, false otherwise.
      */
     boolean matchTitle(String title);
 

--- a/src/main/java/org/cloudsimplus/builders/tables/TableColumn.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/TableColumn.java
@@ -31,6 +31,11 @@ package org.cloudsimplus.builders.tables;
  * @since CloudSim Plus 1.0
  */
 public interface TableColumn {
+    /**
+     * Gets the index of the column into the table.
+     * @return
+     */
+    int getIndex();
 
     /**
      * Generates the string that represents the data of the column,

--- a/src/main/java/org/cloudsimplus/builders/tables/TableColumn.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/TableColumn.java
@@ -87,6 +87,14 @@ public interface TableColumn {
     boolean matchTitle(String title);
 
     /**
+     * Checks if the column subtitle matches with a given subtitle,
+     * ignoring left and right spaces (padding).
+     * @param subtitle the subtitle to compare the column to
+     * @return true if the column subtitle matches ignoring padding, false otherwise.
+     */
+    boolean matchSubTitle(String subtitle);
+
+    /**
      * Sets the format to print the column data
      * @param format the format to set
      * @return

--- a/src/main/java/org/cloudsimplus/builders/tables/TextTable.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/TextTable.java
@@ -73,7 +73,7 @@ public class TextTable extends CsvTable {
     }
 
     @Override
-    public TableColumn addColumn(final int index, final String columnTitle) {
-        return addColumn(new TextTableColumn(this, columnTitle));
+    public TableColumn newColumn(final String title, final String subtitle, final String format) {
+        return new TextTableColumn(title, subtitle, format);
     }
 }

--- a/src/main/java/org/cloudsimplus/builders/tables/TextTableColumn.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/TextTableColumn.java
@@ -32,11 +32,11 @@ package org.cloudsimplus.builders.tables;
  */
 public class TextTableColumn extends CsvTableColumn {
     public TextTableColumn(final String title, final String subTitle) {
-        this(null, title, subTitle);
+        this(title, subTitle, "");
     }
 
     public TextTableColumn(final String title) {
-        this(null, title, "");
+        this(title, "", "");
     }
 
     public TextTableColumn(final Table table, final String title, final String subTitle) {
@@ -45,6 +45,10 @@ public class TextTableColumn extends CsvTableColumn {
 
     public TextTableColumn(final Table table, final String title) {
         super(table, title);
+    }
+
+    public TextTableColumn(final String title, final String subTitle, final String format) {
+        super(title, subTitle, format);
     }
 
     @Override


### PR DESCRIPTION
# Fix #404

This PR introduces new methods for controlling the formatting in tables built using the `TableBuilderAbstract` class, such as `CloudletsTableBuilder`. It also changes the default formatting behavior of `CloudletsTableBuilder` to deliver more precision by default and make potential rounding errors rarer and easier to spot. 

In `CloudletsTableBuilder.java` it removes a rounding method that is no longer needed and refactors the code in the `createTableColumns()` method.

In `TableBuilderAbstract.java` it introduces new methods that allow users to adjust the formatting of one or multiple columns using various selectors with methods that can be chained, following the example of `setTitle()`.

I have already prepared a new example scenario for this feature which will go in this separate PR to the cloudsimplus-example repo: https://github.com/cloudsimplus/cloudsimplus-examples/pull/8