### PR TITLE
Introducing task multithreading for NetworkCloudlets

### DIFF
--- a/src/main/java/org/cloudbus/cloudsim/cloudlets/network/CloudletTask.java
+++ b/src/main/java/org/cloudbus/cloudsim/cloudlets/network/CloudletTask.java
@@ -50,6 +50,8 @@ public abstract class CloudletTask implements Identifiable {
 
     /** @see #getCloudlet() */
     private NetworkCloudlet cloudlet;
+    
+    private CloudletTaskGroup taskGroup;
 
     /**
      * Creates a new task.
@@ -61,6 +63,20 @@ public abstract class CloudletTask implements Identifiable {
         this.startTime = -1;
         this.finishTime = -1;
         this.memory = 0;
+    }
+    
+    public void removeTaskGroup() {
+    	this.taskGroup.removeTask(this);
+    	this.taskGroup = null;
+    }
+
+    public void setTaskGroup(CloudletTaskGroup taskGroup) {
+    	this.taskGroup = taskGroup;
+    	//taskGroup.addTask(this);
+    }
+
+    public CloudletTaskGroup getTaskGroup() {
+    	return taskGroup;
     }
 
     /**

--- a/src/main/java/org/cloudbus/cloudsim/cloudlets/network/CloudletTask.java
+++ b/src/main/java/org/cloudbus/cloudsim/cloudlets/network/CloudletTask.java
@@ -198,6 +198,10 @@ public abstract class CloudletTask implements Identifiable {
     public boolean isExecutionTask(){
         return this instanceof CloudletExecutionTask;
     }
+    
+    public boolean isNetworkingTask() {
+    	return isSendTask() || isReceiveTask() ;
+    }
 
     public boolean isSendTask(){
         return this instanceof CloudletSendTask;

--- a/src/main/java/org/cloudbus/cloudsim/cloudlets/network/CloudletTask.java
+++ b/src/main/java/org/cloudbus/cloudsim/cloudlets/network/CloudletTask.java
@@ -10,6 +10,9 @@ package org.cloudbus.cloudsim.cloudlets.network;
 import org.cloudbus.cloudsim.cloudlets.Cloudlet;
 import org.cloudbus.cloudsim.cloudlets.CloudletExecution;
 import org.cloudbus.cloudsim.core.Identifiable;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
+
 
 /**
  * An abstract class to be implemented by tasks that can be executed by a {@link NetworkCloudlet}.
@@ -34,6 +37,9 @@ import org.cloudbus.cloudsim.core.Identifiable;
  * and {@link CloudletExecution} share a common set of attributes that would be defined by a common interface.
  */
 public abstract class CloudletTask implements Identifiable {
+	
+	Logger LOGGER = LoggerFactory.getLogger(CloudletTask.class.getSimpleName());
+	
     private boolean finished;
 
     /** @see #getId() */
@@ -179,6 +185,7 @@ public abstract class CloudletTask implements Identifiable {
         //If the task wasn't finished before and try to set it to finished, stores the finishTime
         if(!this.finished && finished) {
             finishTime = cloudlet.getSimulation().clock();
+            LOGGER.trace("Task {} of type {} finished on cloudlet {}",getId(),this.getClass().getSimpleName(),getCloudlet().getId());
         }
 
         this.finished = finished;

--- a/src/main/java/org/cloudbus/cloudsim/cloudlets/network/CloudletTask.java
+++ b/src/main/java/org/cloudbus/cloudsim/cloudlets/network/CloudletTask.java
@@ -139,6 +139,9 @@ public abstract class CloudletTask implements Identifiable {
     }
 
     public CloudletTask setCloudlet(final NetworkCloudlet cloudlet) {
+    	if(cloudlet == null) {
+    		throw new IllegalStateException("Cloudlet is null.");
+    	}
         this.cloudlet = cloudlet;
         return this;
     }

--- a/src/main/java/org/cloudbus/cloudsim/cloudlets/network/CloudletTaskGroup.java
+++ b/src/main/java/org/cloudbus/cloudsim/cloudlets/network/CloudletTaskGroup.java
@@ -1,0 +1,116 @@
+package org.cloudbus.cloudsim.cloudlets.network;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.cloudbus.cloudsim.core.CloudSimTag;
+
+public class CloudletTaskGroup {
+
+	private List<CloudletTask> tasks;
+
+	/**
+     * The index of the active running task or -1 if no task has started yet.
+     */
+	private int currentTaskNum;
+	private NetworkCloudlet cloudlet;
+
+	public CloudletTaskGroup() {
+		tasks = new ArrayList<CloudletTask>();
+		currentTaskNum = -1;
+	}
+
+	public CloudletTaskGroup(List<CloudletTask> taskList) {
+		this();
+		tasks.addAll(taskList);
+	}
+
+	public void addTask(CloudletTask task) {
+		task.setTaskGroup(this);
+		tasks.add(task);
+	}
+
+	public void removeTask(CloudletTask task) {
+		task.removeTaskGroup();
+		tasks.remove(task);
+	}
+
+	public List<CloudletTask> getTasks(){
+		return Collections.unmodifiableList(tasks);
+	}
+
+	public CloudletTask getCurrentTask() {
+		return tasks.get(currentTaskNum);
+	}
+
+	public int getCurrentTaskNum(){
+		return currentTaskNum;
+	}
+
+	public boolean isActive() {
+		return currentTaskNum > -1;
+	}
+
+	public boolean isFinished() {
+		boolean isFinished = true;
+		for(CloudletTask t : this.tasks) {
+			isFinished = t.isFinished() && isFinished;
+		}
+		return isFinished;
+	}
+
+	public NetworkCloudlet getCloudlet() {
+		return cloudlet;
+	}
+
+	public void setCloudlet(NetworkCloudlet cloudlet) {
+		this.cloudlet = cloudlet;
+	}
+
+
+
+	/**
+     * Gets an {@link Optional} containing the next task in the list if the current task is finished.
+     *
+     * @return the next task if the current one is finished;
+     *         otherwise an {@link Optional#empty()} if the current task is already the last one,
+     *         or it is not finished yet.
+     */
+    Optional<CloudletTask> getNextTaskIfCurrentIsFinished(){
+
+        if(getCurrentTask().isActive()) {
+            return Optional.empty();
+        }
+
+        if(this.currentTaskNum <= tasks.size()-1) {
+            this.currentTaskNum++;
+        }
+
+        return Optional.of(getCurrentTask());
+    }
+
+    /**
+     * Change the current task to the next one in order
+     * to start executing it, if the current task is finished.
+     *
+     * @param nextTaskStartTime the time that the next task will start
+     * @return true if the current task finished and the next one was started, false otherwise
+     */
+    boolean startNextTaskIfCurrentIsFinished(final double nextTaskStartTime){
+        return
+            getNextTaskIfCurrentIsFinished()
+                .map(task -> task.setStartTime(nextTaskStartTime))
+                .isPresent();
+    }
+
+    public long getLength() {
+        return getTasks().stream()
+                .filter(CloudletTask::isExecutionTask)
+                .map(task -> (CloudletExecutionTask)task)
+                .mapToLong(CloudletExecutionTask::getLength)
+                .sum();
+    }
+
+}

--- a/src/main/java/org/cloudbus/cloudsim/cloudlets/network/CloudletTaskGroup.java
+++ b/src/main/java/org/cloudbus/cloudsim/cloudlets/network/CloudletTaskGroup.java
@@ -28,6 +28,7 @@ public class CloudletTaskGroup {
 	}
 
 	public void addTask(CloudletTask task) {
+		task.setCloudlet(this.cloudlet);
 		task.setTaskGroup(this);
 		tasks.add(task);
 	}

--- a/src/main/java/org/cloudbus/cloudsim/cloudlets/network/CloudletTaskGroup.java
+++ b/src/main/java/org/cloudbus/cloudsim/cloudlets/network/CloudletTaskGroup.java
@@ -40,9 +40,17 @@ public class CloudletTaskGroup {
 	public List<CloudletTask> getTasks(){
 		return Collections.unmodifiableList(tasks);
 	}
+	
+	public int getNumberOfTasks() {
+		return tasks.size();
+	}
 
-	public CloudletTask getCurrentTask() {
-		return tasks.get(currentTaskNum);
+	public Optional<CloudletTask> getCurrentTask() {
+		if (getCurrentTaskNum() < 0 || getCurrentTaskNum() >= getNumberOfTasks()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(tasks.get(getCurrentTaskNum()));
 	}
 
 	public int getCurrentTaskNum(){
@@ -80,15 +88,18 @@ public class CloudletTaskGroup {
      */
     Optional<CloudletTask> getNextTaskIfCurrentIsFinished(){
 
-        if(getCurrentTask().isActive()) {
-            return Optional.empty();
-        }
+    	if(getCurrentTask().isPresent()) {
+    		if(getCurrentTask().get().isActive()) {
+                return Optional.empty();
+            }
+    	}
+        
 
         if(this.currentTaskNum <= tasks.size()-1) {
             this.currentTaskNum++;
         }
 
-        return Optional.of(getCurrentTask());
+        return getCurrentTask();
     }
 
     /**

--- a/src/main/java/org/cloudbus/cloudsim/cloudlets/network/CloudletTaskGroup.java
+++ b/src/main/java/org/cloudbus/cloudsim/cloudlets/network/CloudletTaskGroup.java
@@ -6,8 +6,9 @@ import java.util.List;
 import java.util.Optional;
 
 import org.cloudbus.cloudsim.core.CloudSimTag;
+import org.cloudbus.cloudsim.core.Identifiable;
 
-public class CloudletTaskGroup {
+public class CloudletTaskGroup implements Identifiable {
 
 	private List<CloudletTask> tasks;
 
@@ -16,10 +17,13 @@ public class CloudletTaskGroup {
      */
 	private int currentTaskNum;
 	private NetworkCloudlet cloudlet;
+	
+	private long id;
 
 	public CloudletTaskGroup() {
 		tasks = new ArrayList<CloudletTask>();
 		currentTaskNum = -1;
+		id = -1;
 	}
 
 	public CloudletTaskGroup(List<CloudletTask> taskList) {
@@ -128,5 +132,14 @@ public class CloudletTaskGroup {
                 .mapToLong(CloudletExecutionTask::getLength)
                 .sum();
     }
+
+    public void setId(long id) {
+    	this.id = id;
+    }
+    
+	@Override
+	public long getId() {
+		return this.id;
+	}
 
 }

--- a/src/main/java/org/cloudbus/cloudsim/cloudlets/network/CloudletTaskGroup.java
+++ b/src/main/java/org/cloudbus/cloudsim/cloudlets/network/CloudletTaskGroup.java
@@ -56,6 +56,10 @@ public class CloudletTaskGroup {
 	public int getCurrentTaskNum(){
 		return currentTaskNum;
 	}
+	
+	public boolean isEmpty() {
+		return tasks.size() < 1;
+	}
 
 	public boolean isActive() {
 		return currentTaskNum > -1;

--- a/src/main/java/org/cloudbus/cloudsim/cloudlets/network/NetworkCloudlet.java
+++ b/src/main/java/org/cloudbus/cloudsim/cloudlets/network/NetworkCloudlet.java
@@ -123,6 +123,16 @@ public class NetworkCloudlet extends CloudletSimple {
     public Optional<CloudletTask> getCurrentTask() {
         return defaultTaskGroup.getCurrentTask();
     }
+    
+    public List<CloudletTask> getAllCurrentTasks(){
+    	ArrayList<CloudletTask> allCurrentTasks = new ArrayList<CloudletTask>();
+    	
+    	for(CloudletTaskGroup g : getTaskGroups()) {
+    		g.getCurrentTask().ifPresent(task -> allCurrentTasks.add(task));
+    	}
+    	
+    	return allCurrentTasks;
+    }
 
 
     @Override

--- a/src/main/java/org/cloudbus/cloudsim/cloudlets/network/NetworkCloudlet.java
+++ b/src/main/java/org/cloudbus/cloudsim/cloudlets/network/NetworkCloudlet.java
@@ -179,6 +179,15 @@ public class NetworkCloudlet extends CloudletSimple {
     	
     	return taskWasStarted;
     }
+    
+    public NetworkCloudlet addTaskGroup(final CloudletTaskGroup taskGroup) {
+    	
+    	Objects.requireNonNull(taskGroup);
+    	taskGroups.add(taskGroup);
+    	taskGroup.setCloudlet(this);
+    	
+		return this;
+    }
 
     @Override
     public NetworkVm getVm() {

--- a/src/main/java/org/cloudbus/cloudsim/cloudlets/network/NetworkCloudlet.java
+++ b/src/main/java/org/cloudbus/cloudsim/cloudlets/network/NetworkCloudlet.java
@@ -65,6 +65,7 @@ public class NetworkCloudlet extends CloudletSimple {
     public NetworkCloudlet(final int id,  final long length, final int pesNumber) {
         super(id, length, pesNumber);
         this.defaultTaskGroup = new CloudletTaskGroup();
+        this.defaultTaskGroup.setCloudlet(this);
         this.taskGroups = new ArrayList<>();
         this.taskGroups.add(defaultTaskGroup);
     }

--- a/src/main/java/org/cloudbus/cloudsim/schedulers/cloudlet/network/CloudletTaskSchedulerSimple.java
+++ b/src/main/java/org/cloudbus/cloudsim/schedulers/cloudlet/network/CloudletTaskSchedulerSimple.java
@@ -74,11 +74,11 @@ public class CloudletTaskSchedulerSimple implements CloudletTaskScheduler {
          *       including these if's for each type of task.
          */
         if (isTimeToUpdateCloudletProcessing(netCloudlet))
-            updateAllExecutionTasks(netCloudlet, partialFinishedMI);
+            updateExecutionTasks(netCloudlet, partialFinishedMI);
         else updateNetworkTasks(netCloudlet);
     }
 
-    private void updateAllExecutionTasks(final NetworkCloudlet cloudlet, final long partialFinishedMI) {
+    private void updateExecutionTasks(final NetworkCloudlet cloudlet, final long partialFinishedMI) {
         /*
          * @TODO autor: manoelcampos It has to be checked if the task execution
          *       is considering only one cloudlet PE or all PEs.

--- a/src/main/java/org/cloudbus/cloudsim/schedulers/cloudlet/network/CloudletTaskSchedulerSimple.java
+++ b/src/main/java/org/cloudbus/cloudsim/schedulers/cloudlet/network/CloudletTaskSchedulerSimple.java
@@ -65,7 +65,7 @@ public class CloudletTaskSchedulerSimple implements CloudletTaskScheduler {
 
         final var netCloudlet = (NetworkCloudlet) cloudlet;
         if (!netCloudlet.isTasksStarted()) {
-            scheduleNextTaskIfCurrentIsFinished(netCloudlet);
+            scheduleNextTaskForAllGroupsWhereCurrentIsFinished(netCloudlet);
             return;
         }
 
@@ -87,7 +87,7 @@ public class CloudletTaskSchedulerSimple implements CloudletTaskScheduler {
         final Optional<CloudletExecutionTask> optional = getCloudletCurrentTask(cloudlet);
         optional.ifPresent(task -> {
             task.process(partialFinishedMI);
-            scheduleNextTaskIfCurrentIsFinished(cloudlet);
+            scheduleNextTaskForAllGroupsWhereCurrentIsFinished(cloudlet);
         });
     }
 
@@ -135,7 +135,7 @@ public class CloudletTaskSchedulerSimple implements CloudletTaskScheduler {
             sourceCloudlet.getVm());
 
         vmPacketsToSend.addAll(task.getPacketsToSend(sourceCloudlet.getSimulation().clock()));
-        scheduleNextTaskIfCurrentIsFinished(sourceCloudlet);
+        scheduleNextTaskForAllGroupsWhereCurrentIsFinished(sourceCloudlet);
     }
 
     /**
@@ -161,7 +161,7 @@ public class CloudletTaskSchedulerSimple implements CloudletTaskScheduler {
          *       of the expected packets up to a given timeout.
          *       After that, the task has to stop waiting and fail.
          */
-        scheduleNextTaskIfCurrentIsFinished(destinationCloudlet);
+        scheduleNextTaskForAllGroupsWhereCurrentIsFinished(destinationCloudlet);
     }
 
     private void logReceivedPacket(final NetworkCloudlet destinationCloudlet, final VmPacket pkt) {
@@ -204,8 +204,8 @@ public class CloudletTaskSchedulerSimple implements CloudletTaskScheduler {
     /**
      * Schedules the execution of the next task of a given cloudlet.
      */
-    private void scheduleNextTaskIfCurrentIsFinished(final NetworkCloudlet cloudlet) {
-        if(!cloudlet.startNextTaskIfCurrentIsFinished(cloudlet.getSimulation().clock())){
+    private void scheduleNextTaskForAllGroupsWhereCurrentIsFinished(final NetworkCloudlet cloudlet) {
+        if(!cloudlet.startNextTaskForAllGroupsWhereCurrentIsFinished(cloudlet.getSimulation().clock())){
             return;
         }
 

--- a/src/main/java/org/cloudbus/cloudsim/schedulers/cloudlet/network/CloudletTaskSchedulerSimple.java
+++ b/src/main/java/org/cloudbus/cloudsim/schedulers/cloudlet/network/CloudletTaskSchedulerSimple.java
@@ -115,12 +115,19 @@ public class CloudletTaskSchedulerSimple implements CloudletTaskScheduler {
 
     private void updateNetworkTasks(final NetworkCloudlet cloudlet) {
         //TODO Needs to use polymorphism to avoid these ifs
-        cloudlet.getCurrentTask().ifPresent(task -> {
-            if (task instanceof CloudletSendTask sendTask)
-               addPacketsToBeSentFromVm(cloudlet, sendTask);
+    	
+    	List<CloudletTask> allCurrentNetworkingTasks = cloudlet.getAllCurrentTasks().stream().filter(CloudletTask::isNetworkingTask).collect(Collectors.toList());
+    	
+    	for(CloudletTask task : allCurrentNetworkingTasks) {
+    		
+    		if (task instanceof CloudletSendTask sendTask)
+                addPacketsToBeSentFromVm(cloudlet, sendTask);
+    		
             else if (task instanceof CloudletReceiveTask receiveTask)
-                receivePackets(cloudlet, receiveTask);
-        });
+                 receivePackets(cloudlet, receiveTask);
+    		
+    	}
+
     }
 
     @Override

--- a/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
+++ b/src/main/java/org/cloudsimplus/builders/tables/TableBuilderAbstract.java
@@ -177,7 +177,6 @@ public abstract class TableBuilderAbstract<T> {
     }
 
     private void createAndAddTableColumns() {
-        colsMappings = new ArrayList<>();
         createTableColumns();
 
         final var tb = (AbstractTable)table;


### PR DESCRIPTION
# Close #406

An attempt to implement the ideas discussed in #406 .

It introduces a new Class `CloudletTaskGroup` which represents list of tasks to be processed sequentially.
A NetworkCloudlet can have many `CloudletTaskGroups` which all share the available MI (the current implementation uses space sharing which is not quite realistic, but was easier to implement).

I am not quite sure how to handle backwards compatibility. The current implementation can run the existing networking examples but the function names are becoming a bit confusing (for example: What is the `CurrentCloudlet` when there are multiple running?). Changing the functions would help to clear this up but would break old code.

Obviously, this is just a draft. Code comments are quite lacking at the moment and more work will follow soon.