### PR TITLE
Fix #462

### DIFF
--- a/src/main/java/org/cloudsimplus/cloudlets/CloudletExecution.java
+++ b/src/main/java/org/cloudsimplus/cloudlets/CloudletExecution.java
@@ -355,14 +355,29 @@ public class CloudletExecution {
 	}
 
     /**
-     * Computes the time span between the current simulation time and the last
-     * time the processing of a cloudlet was updated.
+     * Computes the actual processing time span between the current simulation time and the last
+     * time the processing of a cloudlet was updated,
+     * subtracting the oversubscription wait time.
      *
      * @param currentTime the current simulation time
      * @return
      */
-    public double timeSpan(final double currentTime) {
-        return currentTime - lastProcessingTime;
+    public double processingTimeSpan(final double currentTime) {
+        final double totalTimeSpan = currentTime - lastProcessingTime;
+        return hasCloudletFileTransferTimePassed(currentTime) ? totalTimeSpan - getLastOverSubscriptionDelay(): 0;
+    }
+
+    /**
+     * Checks if the time to transfer the files required by a Cloudlet to
+     * execute has already passed, in order to start executing the Cloudlet in
+     * fact.
+     *
+     * @param currentTime the current simulation time
+     * @return true if the time to transfer the files has passed, false
+     * otherwise
+     */
+    public boolean hasCloudletFileTransferTimePassed(final double currentTime) {
+        return fileTransferTime == 0 || currentTime - arrivalTime > fileTransferTime || cloudlet.getFinishedLengthSoFar() > 0;
     }
 
     /**

--- a/src/main/java/org/cloudsimplus/cloudlets/CloudletExecution.java
+++ b/src/main/java/org/cloudsimplus/cloudlets/CloudletExecution.java
@@ -355,6 +355,17 @@ public class CloudletExecution {
 	}
 
     /**
+     * Computes the time span between the current simulation time and the last
+     * time the processing of a cloudlet was updated.
+     *
+     * @param currentTime the current simulation time
+     * @return
+     */
+    public double timeSpan(final double currentTime) {
+        return currentTime - lastProcessingTime;
+    }
+
+    /**
      * Adds a given time to the {@link #getVirtualRuntime() virtual runtime}.
      *
      * @param timeToAdd time to add to the virtual runtime  (in seconds)

--- a/src/main/java/org/cloudsimplus/schedulers/cloudlet/CloudletSchedulerAbstract.java
+++ b/src/main/java/org/cloudsimplus/schedulers/cloudlet/CloudletSchedulerAbstract.java
@@ -548,7 +548,7 @@ public abstract class CloudletSchedulerAbstract implements CloudletScheduler {
          * to be transferred from the Datacenter storage.
          */
         final double processingTimeSpan = hasCloudletFileTransferTimePassed(cle, currentTime) ?
-                                                timeSpan(currentTime)  - cle.getLastOverSubscriptionDelay():
+                                                cle.timeSpan(currentTime)  - cle.getLastOverSubscriptionDelay():
                                                 0;
 
         if(cle.hasLastOverSubscriptionDelay())
@@ -835,17 +835,6 @@ public abstract class CloudletSchedulerAbstract implements CloudletScheduler {
         return cle.getFileTransferTime() == 0 ||
                currentTime - cle.getArrivalTime() > cle.getFileTransferTime() ||
                cle.getCloudlet().getFinishedLengthSoFar() > 0;
-    }
-
-    /**
-     * Computes the time span between the current simulation time and the last
-     * time the processing of a cloudlet was updated.
-     *
-     * @param currentTime the current simulation time
-     * @return
-     */
-    protected double timeSpan(final double currentTime) {
-        return currentTime - previousTime;
     }
 
     /**

--- a/src/main/java/org/cloudsimplus/schedulers/cloudlet/CloudletSchedulerAbstract.java
+++ b/src/main/java/org/cloudsimplus/schedulers/cloudlet/CloudletSchedulerAbstract.java
@@ -547,9 +547,7 @@ public abstract class CloudletSchedulerAbstract implements CloudletScheduler {
          * the CPU in this time span, because it is waiting for its required files
          * to be transferred from the Datacenter storage.
          */
-        final double processingTimeSpan = hasCloudletFileTransferTimePassed(cle, currentTime) ?
-                                                cle.timeSpan(currentTime)  - cle.getLastOverSubscriptionDelay():
-                                                0;
+        final double processingTimeSpan = cle.processingTimeSpan(currentTime);
 
         if(cle.hasLastOverSubscriptionDelay())
             cle.setLastOverSubscriptionDelay(0);
@@ -819,22 +817,6 @@ public abstract class CloudletSchedulerAbstract implements CloudletScheduler {
         }
 
         return 0;
-    }
-
-    /**
-     * Checks if the time to transfer the files required by a Cloudlet to
-     * execute has already passed, in order to start executing the Cloudlet in
-     * fact.
-     *
-     * @param cle         Cloudlet to check if the time to transfer the files has passed
-     * @param currentTime the current simulation time
-     * @return true if the time to transfer the files has passed, false
-     * otherwise
-     */
-    private boolean hasCloudletFileTransferTimePassed(final CloudletExecution cle, final double currentTime) {
-        return cle.getFileTransferTime() == 0 ||
-               currentTime - cle.getArrivalTime() > cle.getFileTransferTime() ||
-               cle.getCloudlet().getFinishedLengthSoFar() > 0;
     }
 
     /**

--- a/src/test/java/org/cloudsimplus/cloudlets/CloudletExecutionTest.java
+++ b/src/test/java/org/cloudsimplus/cloudlets/CloudletExecutionTest.java
@@ -1,0 +1,33 @@
+package org.cloudsimplus.cloudlets;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author Manoel Campos da Silva Filho
+ */
+class CloudletExecutionTest {
+    private final CloudletExecution instance = new CloudletExecution(Cloudlet.NULL);
+
+    @Test
+    public void testTimeSpanIntegerTime(){
+        instance.setLastProcessingTime(0);
+        final double expected = 10;
+        assertEquals(expected, instance.processingTimeSpan(expected), 0.01);
+    }
+
+    @Test
+    public void testTimeSpanLessThan1(){
+        instance.setLastProcessingTime(0);
+        final double expected = 0.6;
+        assertEquals(expected, instance.processingTimeSpan(expected), 0.01);
+    }
+
+    @Test
+    public void testTimeSpanGreaterThan1AndLessThan2(){
+        instance.setLastProcessingTime(0);
+        final double expected = 1.7;
+        assertEquals(expected, instance.processingTimeSpan(expected), 0.01);
+    }
+}

--- a/src/test/java/org/cloudsimplus/schedulers/cloudlet/CloudletSchedulerTimeSharedTest.java
+++ b/src/test/java/org/cloudsimplus/schedulers/cloudlet/CloudletSchedulerTimeSharedTest.java
@@ -34,30 +34,6 @@ public class CloudletSchedulerTimeSharedTest {
     }
 
     @Test
-    public void testTimeSpanIntegerTime(){
-        final var cloudlet = new CloudletExecution(Cloudlet.NULL);
-        cloudlet.setLastProcessingTime(0);
-        final double expected = 10;
-        assertEquals(expected, instance.timeSpan(expected), 0.01);
-    }
-
-    @Test
-    public void testTimeSpanLessThan1(){
-        final var cloudlet = new CloudletExecution(Cloudlet.NULL);
-        cloudlet.setLastProcessingTime(0);
-        final double expected = 0.6;
-        assertEquals(expected, instance.timeSpan(expected), 0.01);
-    }
-
-    @Test
-    public void testTimeSpanGreaterThan1AndLessThan2(){
-        final var cloudlet = new CloudletExecution(Cloudlet.NULL);
-        cloudlet.setLastProcessingTime(0);
-        final double expected = 1.7;
-        assertEquals(expected, instance.timeSpan(expected), 0.01);
-    }
-
-    @Test
     public void testCloudletResumeWhenEmptyPausedList() {
         final int cloudletId = 0;
         final double expResult = 0.0;


### PR DESCRIPTION
# Fix #462

Execution time span must consider the last time the Cloudlet processing was updated, not the last time the `CloudletScheduler` was executed, since Cloudlets may have different times they are submitted and their processing updated.