### PR TITLE
Fix #484

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.cloudsimplus</groupId>
     <artifactId>cloudsimplus</artifactId>
-    <version>8.5.1</version>
+    <version>8.5.2</version>
 
     <name>CloudSim Plus API</name>
     <description>CloudSim Plus: A modern, highly extensible and easier-to-use Java 17+ Framework for Modeling and Simulation of Cloud Computing Infrastructures and Services</description>

--- a/src/main/java/org/cloudsimplus/provisioners/ResourceProvisionerSimple.java
+++ b/src/main/java/org/cloudsimplus/provisioners/ResourceProvisionerSimple.java
@@ -100,7 +100,7 @@ public class ResourceProvisionerSimple extends ResourceProvisionerAbstract {
         vmResource.deallocateAllResources();
 
         //De-allocates the virtual resource to make it free on the physical machine
-        getPmResource().deallocateResource(vmAllocatedResource);
+        getPmResource().deallocateResource(vmResource.getCapacity());
         return vmAllocatedResource;
     }
 


### PR DESCRIPTION
# Fix #484

- When creating a VM, the amount of RAM and BW allocated on the Host is the VM requested capacity for such resources. When destroying a VM, just the amount of used resource was deallocated from the underlying Host. However, the VM is not always using 100% of the allocated resource. If the VM's cloudlets are not set a UtilizationModel for RAM or BW, it won't use such resources at all. In that case, when considering the amount of used resource to deallocate, that will have no effect since such an amount will be zero. Therefore, when deallocating VM RAM and BW resources, it's required to consider the total VM resource capacity to deallocate from the underlying physical resource.
- Version bump to 8.5.2